### PR TITLE
Added local_admin_users resouce

### DIFF
--- a/providers/local_admin_users.rb
+++ b/providers/local_admin_users.rb
@@ -8,3 +8,25 @@
 # All rights reserved - EUPL License V 1.1
 # http://www.osor.eu/eupl
 #
+
+action :setup do
+  begin
+    local_admin_list = new_resource.local_admin_list
+
+	group "sudo" do
+	  action :modify
+	  members local_admin_list
+	  append true
+	end
+
+    # TODO:
+    # save current job ids (new_resource.job_ids) as "ok"
+    # raise errors when both username/group not exists
+
+  rescue
+    # TODO:
+    # just save current job ids as "failed"
+    # save_failed_job_ids
+    raise
+  end
+end

--- a/recipes/misc_mgmt.rb
+++ b/recipes/misc_mgmt.rb
@@ -33,3 +33,8 @@ gecos_ws_mgmt_desktop_background node[:gecos_ws_mgmt][:misc_mgmt][:desktop_backg
     action  :setup
 end
 
+gecos_ws_mgmt_local_admin_users 'assert users list as sudoers' do
+  local_admin_list node[:gecos_ws_mgmt][:misc_mgmt][:local_admin_users_res][:local_admin_list]
+  job_ids node[:gecos_ws_mgmt][:misc_mgmt][:local_admin_users_res][:job_ids]
+  action :setup
+end

--- a/resources/local_admin_users.rb
+++ b/resources/local_admin_users.rb
@@ -8,3 +8,8 @@
 # All rights reserved - EUPL License V 1.1
 # http://www.osor.eu/eupl
 #
+
+actions :setup
+
+attribute :local_admin_list, :kind_of => Array
+attribute :job_ids, :kind_of => Array


### PR DESCRIPTION
A straight forward coding using [chef's group resource](http://docs.opscode.com/resource_group.html)
Tested successfully with the following chef-json input:

``` json
{
    "run_list": "recipe[gecos_ws_mgmt::default]",
    "gecos_ws_mgmt": {
        "misc_mgmt": {
            "local_admin_users_res": {
                "local_admin_list": ["ami", "vagrant", "jonas"]
            }
        }
    }
}
```
