### PR TITLE
Fixing input variable declaration on network-mgmt recipe and provider

### DIFF
--- a/providers/network.rb
+++ b/providers/network.rb
@@ -153,12 +153,19 @@ action :setup do
       backup false
     end
     
-    # TODO:
-    # save current job ids as "ok"
-  rescue
-    # TODO:
+    # save current job ids (new_resource.job_ids) as "ok"
+    job_ids = new_resource.job_ids
+    job_ids.each do |jid|
+      node.set['job_status'][jid]['status'] = 0
+    end
+
+  rescue Exception => e
     # just save current job ids as "failed"
     # save_failed_job_ids
-    raise
+    job_ids = new_resource.job_ids
+    job_ids.each do |jid|
+      node.set['job_status'][jid]['status'] = 1
+      node.set['job_status'][jid]['message'] = e.message
+    end
   end
 end

--- a/recipes/network_mgmt.rb
+++ b/recipes/network_mgmt.rb
@@ -10,5 +10,13 @@
 #
 
 gecos_ws_mgmt_network "localhost" do
-  action  :setup
+  gateway node[:gecos_ws_mgmt][:network_mgmt][:network_res][:gateway]
+  ip_address node[:gecos_ws_mgmt][:network_mgmt][:network_res][:ip_address]
+  netmask node[:gecos_ws_mgmt][:network_mgmt][:network_res][:netmask]
+  network_type node[:gecos_ws_mgmt][:network_mgmt][:network_res][:network_type]
+  use_dhcp node[:gecos_ws_mgmt][:network_mgmt][:network_res][:use_dhcp]
+  dns_servers_array node[:gecos_ws_mgmt][:network_mgmt][:network_res][:dns_servers]
+  users node[:gecos_ws_mgmt][:network_mgmt][:network_res][:users]
+  job_ids node[:gecos_ws_mgmt][:network_mgmt][:network_res][:job_ids]
+  action :setup
 end

--- a/resources/network.rb
+++ b/resources/network.rb
@@ -17,4 +17,5 @@ attribute :netmask, :kind_of => String
 attribute :network_type, :kind_of => String
 attribute :use_dhcp, :kind_of => String
 attribute :dns_servers, :kind_of => Array
-attribute :user, :kind_of => String
+attribute :users, :kind_of => Array
+attribute :job_ids, :kind_of => Array


### PR DESCRIPTION
Solicito revisión antes de hacer merge.

En este branch figura el arreglo a network-mgmt a fin de que contemple el uso de los siguientes parámetros de entrada:
- **users**: estaba siendo ignorado y contiene las configuraciones de red por usuario
- **job_ids**: estaba siendo ignorado y contiene el job_id para reportar el estado de los procesos

El esquema de datos de entrada figuraba en el fichero _metadata_.rb del cookbook pero no así en la _recipe_ ni _provider_.
