### PR TITLE
Set a default PATH inside the script

### DIFF
--- a/templates/default/auto_updates.erb
+++ b/templates/default/auto_updates.erb
@@ -14,6 +14,10 @@
 
 NAME=auto_update
 
+# Set path
+PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/local/sbin
+export PATH
+
 set -e
 
 case "$1" in


### PR DESCRIPTION
In my GECOS installation this script failed when executed by CRON because of an empty PATH for "root" user