### PR TITLE
fixes GECOS chef admin certiticiate security issues on workstations

### DIFF
--- a/recipes/local.rb
+++ b/recipes/local.rb
@@ -57,6 +57,11 @@ if not node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_server_url].nil?
     chef_node_name node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_node_name]
     chef_admin_name node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_admin_name]
     chef_link_existing node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_link_existing]
+
+    gcc_endpoint node[:gecos_ws_mgmt][:misc_mgmt][:gcc_res][:gcc_endpoint]
+    gcc_username node[:gecos_ws_mgmt][:misc_mgmt][:gcc_res][:gcc_username]
+    gcc_password node[:gecos_ws_mgmt][:misc_mgmt][:gcc_res][:gcc_password]
+
     job_ids []
     support_os node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:support_os]
     action  :setup

--- a/recipes/unlink_from_chef.rb
+++ b/recipes/unlink_from_chef.rb
@@ -13,6 +13,11 @@ gecos_ws_mgmt_chef node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_server
   chef_validation_pem "chef_validation_pem"
   chef_node_name node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_node_name]
   chef_admin_name node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:chef_admin_name]
+
+  gcc_endpoint node[:gecos_ws_mgmt][:misc_mgmt][:gcc_res][:gcc_endpoint]
+  gcc_username node[:gecos_ws_mgmt][:misc_mgmt][:gcc_res][:gcc_username]
+  gcc_password node[:gecos_ws_mgmt][:misc_mgmt][:gcc_res][:gcc_password]
+
   job_ids []
   support_os node[:gecos_ws_mgmt][:misc_mgmt][:chef_conf_res][:support_os]
   action  :setup

--- a/resources/chef.rb
+++ b/resources/chef.rb
@@ -18,6 +18,9 @@ attribute :chef_link_existing, :kind_of => [ TrueClass, FalseClass ], :default =
 attribute :chef_node_name, :kind_of => String
 attribute :chef_admin_name, :kind_of => String
 attribute :chef_validation_pem, :kind_of => String
+attribute :gcc_endpoint, :kind_of => String
+attribute :gcc_username, :kind_of => String
+attribute :gcc_password, :kind_of => String
 attribute :job_ids, :kind_of => Array
 attribute :support_os, :kind_of => Array
 

--- a/templates/default/client.rb.erb
+++ b/templates/default/client.rb.erb
@@ -15,7 +15,7 @@ file_backup_path   "/var/lib/chef/backup"
 
 pid_file           "/var/run/chef/client.pid"
 
-validation_client_name "<%= @chef_admin_name %>"
+validation_client_name "chef-validator"
 
 require "/usr/share/gecosws-config-assistant/report-handlers/gecoshandlers"
 reporthandler = GECOSReports::StatusHandler.new


### PR DESCRIPTION
changed the linking (now using the standar validation.pem) and unlinking logic to use GCC controller instead of a chef-server admin certificate