### PR TITLE
bugix. The .cache directory was created with "root" user as owner.

### DIFF
--- a/providers/gsettings.rb
+++ b/providers/gsettings.rb
@@ -22,7 +22,7 @@ def initialize(*args)
   unless Kernel::test('d', dconf_cache_dir)
     FileUtils.mkdir_p dconf_cache_dir
     gid = Etc.getpwnam(new_resource.username).gid
-    FileUtils.chown_R(new_resource.username, gid, dconf_cache_dir)
+    FileUtils.chown_R(new_resource.username, gid, "/home/#{new_resource.username}/.cache")
   end
   begin
     dbus_file = Dir["/home/#{new_resource.username}/.dbus/session-bus/*0"].last


### PR DESCRIPTION
Please consider this patch as a bugfix for the owner of .cache directory