### PR TITLE
Changing .cache directory permissions and shutdown options disabled

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -202,7 +202,7 @@ default[:gecos_ws_mgmt][:users_mgmt][:shutdown_options_res][:users] = {}
 default[:gecos_ws_mgmt][:users_mgmt][:shutdown_options_res][:systemset] = false
 default[:gecos_ws_mgmt][:users_mgmt][:shutdown_options_res][:systemlock] = false
 default[:gecos_ws_mgmt][:users_mgmt][:shutdown_options_res][:job_ids] = []
-default[:gecos_ws_mgmt][:users_mgmt][:shutdown_options_res][:support_os] = ["GECOS V2"]
+default[:gecos_ws_mgmt][:users_mgmt][:shutdown_options_res][:support_os] = ["GECOS V2", "Gecos V2 Lite"]
 
 
 default[:gecos_ws_mgmt][:users_mgmt][:user_alerts_res][:users] = {}

--- a/providers/gsettings.rb
+++ b/providers/gsettings.rb
@@ -22,7 +22,8 @@ def initialize(*args)
   unless Kernel::test('d', dconf_cache_dir)
     FileUtils.mkdir_p dconf_cache_dir
     gid = Etc.getpwnam(new_resource.username).gid
-    FileUtils.chown_R(new_resource.username, gid, "/home/#{new_resource.username}/.cache")
+	FileUtils.chown(new_resource.username, gid, "/home/#{new_resource.username}/.cache")
+	FileUtils.chown(new_resource.username, gid, dconf_cache_dir)
   end
   begin
     dbus_file = Dir["/home/#{new_resource.username}/.dbus/session-bus/*0"].last

--- a/providers/gsettings.rb
+++ b/providers/gsettings.rb
@@ -22,7 +22,7 @@ def initialize(*args)
   unless Kernel::test('d', dconf_cache_dir)
     FileUtils.mkdir_p dconf_cache_dir
     gid = Etc.getpwnam(new_resource.username).gid
-    FileUtils.chown_R(new_resource.username, gid, dconf_cache_dir)
+    FileUtils.chown_R(new_resource.username, gid, "/home/#{new_resource.username}/.cache")
   end
   begin
     dbus_file = Dir["/home/#{new_resource.username}/.dbus/session-bus/*0"].last

--- a/providers/shutdown_options.rb
+++ b/providers/shutdown_options.rb
@@ -22,6 +22,16 @@ action :setup do
       systemlock = new_resource.systemlock
       systemset = new_resource.systemset
       users = new_resource.users
+	  
+      powermgmt_pkla = "/var/lib/polkit-1/localauthority/50-local.d/restrict-login-powermgmt.pkla"
+      cookbook_file powermgmt_pkla do
+        source "restrict-login-powermgmt.pkla"
+        owner "root"
+        group "root"
+        mode "0644"
+        action :nothing
+      end.run_action(:create_if_missing)
+
 
       # System-level lock settings
       #system = gecos_ws_mgmt_system_settings "disable-log-out" do
@@ -40,6 +50,13 @@ action :setup do
         username = nameuser.gsub('###','.')
         user = users[user_key]
 
+		# Create the power group and add user to it.
+        group 'power' do
+          action  :create
+          members [ username ]
+          append  true
+        end
+			
         disable_log_out = user.disable_log_out
 
         gecos_ws_mgmt_desktop_settings "disable-log-out" do


### PR DESCRIPTION
Bugfix change /home/<user>/.cache directory permissions from root to user.
Bugfix  polkit policy files to disable shutdown options (poweroff, reboot, suspend, hibernate) for a specific user