### PR TITLE
Bugfix: "stdout is not a method for String class" 

### DIFF
--- a/providers/appconfig_firefox.rb
+++ b/providers/appconfig_firefox.rb
@@ -46,6 +46,7 @@ action :setup do
           variables(
             :settings => new_resource.config_firefox
           )
+          not_if {installdir.empty?}
         end.run_action(:create)
 
         link "#{installdir}/update.js" do
@@ -53,7 +54,7 @@ action :setup do
           only_if 'test -f /etc/firefox/update.js'
         end
 
-        link "#{installdir.stdout.chomp}/proxy-prefs.js" do
+        link "#{installdir}/proxy-prefs.js" do
           to "/etc/firefox/proxy-prefs.js"
           only_if 'test -f /etc/firefox/proxy-prefs.js'
         end

--- a/providers/appconfig_firefox.rb
+++ b/providers/appconfig_firefox.rb
@@ -46,6 +46,7 @@ action :setup do
           variables(
             :settings => new_resource.config_firefox
           )
+          not_if {installdir.empty?}
         end.run_action(:create)
 
         link "#{installdir}/update.js" do

--- a/providers/appconfig_firefox.rb
+++ b/providers/appconfig_firefox.rb
@@ -46,7 +46,6 @@ action :setup do
           variables(
             :settings => new_resource.config_firefox
           )
-          not_if {installdir.empty?}
         end.run_action(:create)
 
         link "#{installdir}/update.js" do

--- a/providers/appconfig_thunderbird.rb
+++ b/providers/appconfig_thunderbird.rb
@@ -49,6 +49,7 @@ action :setup do
           variables(
             :settings => new_resource.config_thunderbird
           )
+          not_if {installdir.empty?}
         end.run_action(:create)
 
         link "#{installdir}/proxy-prefs.js" do

--- a/providers/appconfig_thunderbird.rb
+++ b/providers/appconfig_thunderbird.rb
@@ -49,7 +49,6 @@ action :setup do
           variables(
             :settings => new_resource.config_thunderbird
           )
-          not_if {installdir.empty?}
         end.run_action(:create)
 
         link "#{installdir}/proxy-prefs.js" do


### PR DESCRIPTION
Solved error "stdout is not a method for String class"  from comments in https://github.com/gecos-team/gecos-workstation-management-cookbook/commit/48f1ec844f70608278174ebca17af3e93a964f2a

