### PR TITLE
Change auto_shutdown template to use the appropiate GECOS snitch client.

### DIFF
--- a/providers/power_conf.rb
+++ b/providers/power_conf.rb
@@ -64,7 +64,8 @@ action :setup do
           mode "0755"
           owner "root"
           variables({ :hour => auto_shutdown.hour, :minute => auto_shutdown.minute, :first_warn_hour => first_warn_hour,
-           :first_warn_minute => first_warn_minute, :last_warn_hour => last_warn_hour, :last_warn_minute => last_warn_minute })
+           :first_warn_minute => first_warn_minute, :last_warn_hour => last_warn_hour, :last_warn_minute => last_warn_minute,
+           :snitch_binary => $snitch_binary })
           notifies :restart, "service[cron]", :delayed
           action :nothing
         end.run_action(:create)

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,13 +21,13 @@ end
 # Snitch, the chef notifier has been renamed
 # TODO: move this to chef-client-wrapper
 if ::File.exists?("/usr/bin/gecos-snitch-client")
-  snitch_binary="/usr/bin/gecos-snitch-client"
+  $snitch_binary="/usr/bin/gecos-snitch-client"
 else
-  snitch_binary="/usr/bin/gecosws-chef-snitch-client"
+  $snitch_binary="/usr/bin/gecosws-chef-snitch-client"
 end  
 
 execute "gecos-snitch-client" do
-  command "#{snitch_binary} --set-active true"
+  command "#{$snitch_binary} --set-active true"
   action :nothing
 end.run_action(:run)
 

--- a/templates/default/auto_shutdown.erb
+++ b/templates/default/auto_shutdown.erb
@@ -1,6 +1,6 @@
 # cron file to manage system shutdown
 
-<%= @first_warn_minute %> <%= @first_warn_hour %> * * * root gecosws-chef-snitch-client --set-message "El sistema se apagara en 30 minutos"
-<%= @last_warn_minute %> <%= @last_warn_hour %> * * * root gecosws-chef-snitch-client --set-message "El sistema se apagara en 5 minutos"
+<%= @first_warn_minute %> <%= @first_warn_hour %> * * * root <%= @snitch_binary %> --set-message "El sistema se apagara en 30 minutos"
+<%= @last_warn_minute %> <%= @last_warn_hour %> * * * root <%= @snitch_binary %> --set-message "El sistema se apagara en 5 minutos"
 <%= @minute %> <%= @hour %> * * * root /sbin/shutdown -P now
 


### PR DESCRIPTION
Since GECOS snitch client script name was changed from "gecosws-chef-snitch-client" to "gecos-snitch-client", the "auto_shutdown" template must use the appropiate one.