### PR TITLE
Create firefox pref dir before use it

### DIFF
--- a/providers/printers.rb
+++ b/providers/printers.rb
@@ -79,14 +79,8 @@ action :setup do
       printers_list.each do |printer|
         Chef::Log.info("Processing printer: #{printer.name}")
 
-        # HP printers are bad labeled in database
-        curr_ptr_manuf=printer.manufacturer
-        if curr_ptr_manuf== 'Hp'
-          curr_ptr_manuf='HP'
-        end
-
         curr_ptr_name  = printer.name.gsub(" ","+")
-        curr_ptr_id    = curr_ptr_manuf.gsub(" ","-") + "-" + printer.model.gsub(" ","_")
+        curr_ptr_id    = printer.manufacturer.gsub(" ","-") + "-" + printer.model.gsub(" ","_")
 
         oppolicy = 'default'
         if printer.attribute?('oppolicy')

--- a/providers/printers.rb
+++ b/providers/printers.rb
@@ -79,8 +79,14 @@ action :setup do
       printers_list.each do |printer|
         Chef::Log.info("Processing printer: #{printer.name}")
 
+        # HP printers are bad labeled in database
+        curr_ptr_manuf=printer.manufacturer
+        if curr_ptr_manuf== 'Hp'
+          curr_ptr_manuf='HP'
+        end
+
         curr_ptr_name  = printer.name.gsub(" ","+")
-        curr_ptr_id    = printer.manufacturer.gsub(" ","-") + "-" + printer.model.gsub(" ","_")
+        curr_ptr_id    = curr_ptr_manuf.gsub(" ","-") + "-" + printer.model.gsub(" ","_")
 
         oppolicy = 'default'
         if printer.attribute?('oppolicy')

--- a/providers/web_browser.rb
+++ b/providers/web_browser.rb
@@ -270,6 +270,15 @@ action :setup do
           ## Plugins STUFF
           unless plugins.empty?
             Chef::Log.info("Setting user #{username} web plugins")  
+
+            directory "/etc/firefox/pref" do
+              owner    'root'
+              group    'root'
+              mode     '0755'
+              recursive true
+              action :nothing
+            end.run_action(:create)
+
             template "/etc/firefox/pref/web_browser_res.js" do
               source "web_browser_scope.js.erb"
               action :nothing


### PR DESCRIPTION
With brand, new workstations, `web_browser` policy uses `/etc/firefox/pref` folder without checking if it exists. This code check for this directory and creates if it doesn't exists.