### PR TITLE
Checking connectivity with the chef server in addition to GCC

### DIFF
--- a/providers/appconfig_firefox.rb
+++ b/providers/appconfig_firefox.rb
@@ -38,6 +38,8 @@ action :setup do
           variables(
             :app_update => app_update
           )
+          not_if {app_update.nil?}
+          action :nothing
         end.run_action(:create)
 
         template "/etc/firefox/proxy-prefs.js" do
@@ -47,6 +49,8 @@ action :setup do
             :settings => new_resource.config_firefox
           )
           not_if {installdir.empty?}
+          not_if {new_resource.config_firefox['mode'].nil?} 
+          action :nothing
         end.run_action(:create)
 
         link "#{installdir}/update.js" do

--- a/providers/system_settings.rb
+++ b/providers/system_settings.rb
@@ -124,3 +124,23 @@ action :unlock do
     command "dconf update"
   end.run_action(:run)
 end
+
+action :clear do
+  dconfdb = 'gecos'
+  schema = new_resource.schema
+  regex = "#{schema.gsub('/','-')}*"
+
+  # Delete all files of schema
+  Dir["/etc/dconf/db/#{dconfdb}.d/#{regex}"].each do |fe|
+    Chef::Log.debug("system_settings.rb - fe:#{fe}")
+    file "#{fe}" do
+      backup false
+      action :nothing
+    end.run_action(:delete)
+  end
+
+  execute "update-dconf" do
+    action :nothing
+    command "dconf update"
+  end.run_action(:run)
+end

--- a/resources/system_settings.rb
+++ b/resources/system_settings.rb
@@ -10,7 +10,7 @@
 #
 
 
-actions :set, :unset, :lock, :unlock
+actions :set, :unset, :lock, :unlock, :clear
 
 attribute :schema, :kind_of => String, :required => true
 attribute :name, :kind_of => String, :name_attribute => true

--- a/templates/default/apt_proxy.erb
+++ b/templates/default/apt_proxy.erb
@@ -1,4 +1,6 @@
-<% if ( ! @proxy_settings['disable_proxy']) and ( @proxy_settings['proxy_autoconfig_url'].nil? or @proxy_settings['proxy_autoconfig_url'].empty? ) %>
+<% if @proxy_settings['http_proxy'] and !@proxy_settings['http_proxy'].empty? %>
 Acquire::http::Proxy "<%= @proxy_settings['http_proxy'] %>:<%= @proxy_settings['http_proxy_port'] %>";
+<% end %>
+<% if @proxy_settings['https_proxy'] and !@proxy_settings['https_proxy'].empty? %>
 Acquire::https::Proxy "<%= @proxy_settings['https_proxy'] %>:<%= @proxy_settings['https_proxy_port'] %>";
 <% end %>

--- a/templates/default/mozilla_proxy.erb
+++ b/templates/default/mozilla_proxy.erb
@@ -5,11 +5,11 @@
 pref("network.proxy.type",0);
 <%  when 1 %>
 pref("network.proxy.type",1);
-<% if not @settings['http_proxy'].nil? %>
+<% if @settings['http_proxy'] and !@settings['http_proxy'].empty?  %>
 pref("network.proxy.http","<%= @settings['http_proxy'] %>");
 pref("network.proxy.http_port", <%= @settings['http_proxy_port'] %>);
 <% end %>
-<% if not @settings['https_proxy'].nil? %>
+<% if @settings['https_proxy'] and !@settings['https_proxy'].empty? %>
 pref("network.proxy.ssl","<%= @settings['https_proxy'] %>");
 pref("network.proxy.ssl_port", <%= @settings['https_proxy_port'] %>);
 <% end %>


### PR DESCRIPTION
Chef-client uses the environment variables. When proxy settings are applied, chef-client attempts to connect to the chef server via the proxy. If there is no connectivity to the proxy, then it should be detected and returned to a valid network configuration.