### PR TITLE
Display manager policy

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -76,6 +76,13 @@ default[:gecos_ws_mgmt][:software_mgmt][:appconfig_java_res][:job_ids] = []
 default[:gecos_ws_mgmt][:software_mgmt][:appconfig_java_res][:updated_by] = {} 
 default[:gecos_ws_mgmt][:software_mgmt][:appconfig_java_res][:support_os] = ["GECOS V3", "GECOS V2", "Gecos V2 Lite", "GECOS V3 Lite"]
 
+default[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:dm] = 'MDM'
+default[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:autologin] = false
+default[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:autologin_options] = {}
+default[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:job_ids] = [] 
+default[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:updated_by] = {} 
+default[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:support_os] = ["GECOS V3", "GECOS V2", "Gecos V2 Lite", "GECOS V3 Lite"]
+
 default[:gecos_ws_mgmt][:printers_mgmt][:printers_res][:printers_list] = []
 default[:gecos_ws_mgmt][:printers_mgmt][:printers_res][:job_ids] = []
 default[:gecos_ws_mgmt][:printers_mgmt][:printers_res][:updated_by] = {}

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer        "GECOS Team"
 maintainer_email  "gecos@guadalinex.org"
 license           "Apache 2.0"
 description       "Cookbook for GECOS workstations administration"
-version           "0.5.13"
+version           "0.5.14"
 
 depends "apt"
 depends "chef-client"
@@ -2032,6 +2032,7 @@ local_file_js = {
   title_es: "Archivos locales",
   type: "object",
   required: ["localfiles"],
+                                        
   is_mergeable: true,
   autoreverse: false,
   additionalProperties: false,
@@ -2449,6 +2450,58 @@ system_proxy_js = {
   }
 }
 
+display_manager_js = {
+  title: "Display Manager",
+  title_es: "Gestor de inicio de sesión",
+  type: "object",
+  is_mergeable: false,
+  autoreversible: false,
+  properties:
+  {
+    dm: {
+      type: "string",
+      title: "Select a DM",
+      title_es: "Selecciona un DM",
+      enum: ["MDM", "Lightdm"],
+      description: "Autologin timeout in MDM is set to more than 5 seconds and it cannot be changed. For a kiosk-like client it is recommended LightDM as display manager because it has no minimum timeout",
+      description_es: "MDM tiene un tiempo de espera de login automático no inferior a 5 segundos. Para un kiosco se recomienda la opción LightDM al no tener tiempo de espera mínimo"
+    },
+    autologin: {
+      type:"boolean",
+      title: "Checking the box will enable login autologin",
+      title_es: "Si activa la casilla, habilitará el login automático"
+    },
+    autologin_options: {
+        type: "object",
+        required: ["username","timeout"],
+        properties: {
+           username: {
+             title: "Username",
+             title_es: "Usuario",
+             type: "string",
+             default: ""
+           },
+           timeout: {
+             title: "Autologin user timeout ",
+             title_es: "Timeout de autologin",
+             type: "integer",
+             default: 15
+           }
+        }
+    },
+    support_os: support_os_js.clone,
+    updated_by: updated_js
+  },
+  dependencies: {
+    autologin: ["autologin_options"]
+  },
+  customFormItems: {
+    autologin: {
+      inlinetitle: "Si activa la casilla, habilitará el login automático",
+      toggleNext: 1
+    }
+  }
+}
 
 idle_timeout_js = {
   title: "Idle session timeout",
@@ -2555,7 +2608,7 @@ ttys_js = {
     support_os: support_os_js.clone,
     updated_by: updated_js
   }
-}                   
+}
 
 network_resource_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 tz_date_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
@@ -2598,6 +2651,7 @@ cert_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 
 mobile_broadband_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 mimetypes_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 system_proxy_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
+display_manager_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 idle_timeout_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 ttys_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 
@@ -2651,7 +2705,7 @@ complete_js = {
         },
         software_mgmt: {
           type: "object",
-          required: ["software_sources_res","package_res", "app_config_res","appconfig_libreoffice_res","appconfig_thunderbird_res","appconfig_firefox_res","appconfig_java_res","package_profile_res"],
+          required: ["software_sources_res","package_res", "app_config_res","appconfig_libreoffice_res","appconfig_thunderbird_res","appconfig_firefox_res","appconfig_java_res","package_profile_res", "display_manager_res"],
           properties: {
             software_sources_res: software_sources_js,
             package_res: package_js,
@@ -2660,7 +2714,8 @@ complete_js = {
             appconfig_libreoffice_res: appconfig_libreoffice_js,
             appconfig_thunderbird_res: appconfig_thunderbird_js,
             appconfig_firefox_res: appconfig_firefox_js,
-            appconfig_java_res: appconfig_java_js
+            appconfig_java_res: appconfig_java_js,
+            display_manager_res: display_manager_js
           }
         },
         printers_mgmt: {

--- a/providers/display_manager.rb
+++ b/providers/display_manager.rb
@@ -38,9 +38,9 @@ action :setup do
           OTHER = 'lightdm'
         else
           PACKAGES = if new_resource.autologin
-            %w(lightdm lightdm-gtk-greeter gecosws-lightdm-autologin)
+            %w(gir1.2-lightdm-1 python-gobject lightdm lightdm-gtk-greeter gecosws-lightdm-autologin)
           else
-            %w(lightdm lightdm-gtk-greeter)
+            %w(gir1.2-lightdm-1 python-gobject lightdm lightdm-gtk-greeter)
           end
           SERVICE = 'lightdm'
           TEMPLATE = 'lightdm.conf.erb'

--- a/providers/display_manager.rb
+++ b/providers/display_manager.rb
@@ -1,0 +1,134 @@
+#
+# Cookbook Name:: gecos-ws-mgmt
+# Provider:: display_manager
+#
+# Copyright 2013, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# All rights reserved - EUPL License V 1.1
+# http://www.osor.eu/eupl
+#
+
+
+V2 = ["GECOS V2","Gecos V2 Lite"]
+
+
+action :setup do
+
+  begin
+
+    # Constants
+    Chef::Log.debug("display_manager.rb ::: $gecos_os = #{$gecos_os}")
+    PROVIDER = case $gecos_os
+      when *V2
+        Chef::Provider::Service::Upstart
+      else 
+        Chef::Provider::Service::Systemd
+    end
+ 
+    if new_resource.support_os.include?($gecos_os)
+
+      case new_resource.dm
+        when 'MDM'
+          PACKAGES = %w(mdm gecosws-mdm-theme)
+          SERVICE = 'mdm'
+          TEMPLATE = 'mdm.conf.erb'
+          CONFIGFILE = '/etc/mdm/mdm.conf'
+          BIN = '/usr/sbin/mdm'
+          OTHER = 'lightdm'
+        else
+          PACKAGES = if new_resource.autologin
+            %w(lightdm lightdm-gtk-greeter gecosws-lightdm-autologin)
+          else
+            %w(lightdm lightdm-gtk-greeter)
+          end
+          SERVICE = 'lightdm'
+          TEMPLATE = 'lightdm.conf.erb'
+          CONFIGFILE = '/etc/lightdm/lightdm.conf'
+          BIN = '/usr/sbin/lightdm'
+          OTHER = 'mdm'
+      end
+
+      Chef::Log.debug("display_manager.rb ::: PROVIDER = #{PROVIDER}")
+      Chef::Log.debug("display_manager.rb ::: SERVICE  = #{SERVICE}")
+      Chef::Log.debug("display_manager.rb ::: PACKAGES = #{PACKAGES}")
+      Chef::Log.debug("display_manager.rb ::: TEMPLATE = #{TEMPLATE}")
+      Chef::Log.debug("display_manager.rb ::: CONFIGFILE = #{CONFIGFILE}")
+
+      # Packages installation
+      PACKAGES.each do |pkg|
+        package pkg do
+          action :install
+        end
+      end
+
+      # Removes extra package (only for lightdm)
+      package 'gecosws-lightdm-autologin' do
+        action :remove
+        only_if { !new_resource.autologin and SERVICE=='lightdm' }
+      end
+
+      # Sets default display manager
+      file '/etc/X11/default-display-manager' do
+        content "#{BIN}\n"
+        action :create
+        notifies :stop, "service[#{OTHER}]", :immediately
+        notifies :disable, "service[#{OTHER}]", :immediately
+      end
+           
+      # Stops current DM
+      service OTHER do
+        provider PROVIDER
+        action :nothing
+      end
+
+      # Enables and starts new DM
+      service SERVICE do
+        provider PROVIDER
+        action [:enable, :start]
+      end
+
+      # Configures DM
+      template CONFIGFILE do
+        source TEMPLATE
+        variables ({
+          :autologin => new_resource.autologin,
+          :autologin_user => new_resource.autologin_options['username'],
+          :autologin_timeout => new_resource.autologin_options['timeout']
+        })
+        notifies :restart, "service[#{SERVICE}]", :delayed
+      end
+
+    else
+      Chef::Log.info("This resource is not support into your OS")
+    end
+    
+    # save current job ids (new_resource.job_ids) as "ok"
+    job_ids = new_resource.job_ids
+    job_ids.each do |jid|
+      node.normal['job_status'][jid]['status'] = 0
+    end
+
+  rescue Exception => e
+    # just save current job ids as "failed"
+    # save_failed_job_ids
+    Chef::Log.error(e.message)
+    job_ids = new_resource.job_ids
+    job_ids.each do |jid|
+      node.normal['job_status'][jid]['status'] = 1
+      if not e.message.frozen?
+        node.normal['job_status'][jid]['message'] = e.message.force_encoding("utf-8")
+      else
+        node.normal['job_status'][jid]['message'] = e.message
+      end
+    end
+
+  ensure
+    
+    gecos_ws_mgmt_jobids "display_manager_res" do
+       recipe "software_mgmt"
+    end.run_action(:reset) 
+    
+  end
+end
+

--- a/recipes/software_mgmt.rb
+++ b/recipes/software_mgmt.rb
@@ -69,3 +69,12 @@ gecos_ws_mgmt_appconfig_java 'java config' do
   support_os node[:gecos_ws_mgmt][:software_mgmt][:appconfig_java_res][:support_os]
   action :setup
 end
+
+gecos_ws_mgmt_display_manager 'display manager' do
+  dm node[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:dm]
+  autologin node[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:autologin]
+  autologin_options node[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:autologin_options]
+  job_ids node[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:job_ids]
+  support_os node[:gecos_ws_mgmt][:software_mgmt][:display_manager_res][:support_os]
+  action :setup
+end

--- a/resources/display_manager.rb
+++ b/resources/display_manager.rb
@@ -1,0 +1,18 @@
+#
+# Cookbook Name:: gecos-ws-mgmt
+# Resource:: display_manager
+#
+# Copyright 2013, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# All rights reserved - EUPL License V 1.1
+# http://www.osor.eu/eupl
+#
+
+actions :setup
+
+attribute :dm, :kind_of => String
+attribute :autologin, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :autologin_options, :kind_of => Hash
+attribute :job_ids, :kind_of => Array
+attribute :support_os, :kind_of => Array

--- a/templates/default/lightdm.conf.erb
+++ b/templates/default/lightdm.conf.erb
@@ -1,0 +1,12 @@
+[SeatDefaults]
+allow-guest=false
+
+<% if @autologin %>
+autologin-guest=false
+autologin-user=<%= @autologin_user %>
+autologin-user-timeout=<%= @autologin_timeout %>
+
+allow-user-switching=true
+greeter-hide-users=true
+greeter-show-manual-login=true
+<% end %>

--- a/templates/default/mdm.conf.erb
+++ b/templates/default/mdm.conf.erb
@@ -1,0 +1,81 @@
+# MDM Configuration file.
+#
+# This file is the appropriate place for specifying your customizations to the
+# MDM configuration. If you run mdmsetup, it will automatically edit this
+# file for you and will cause the daemon and any running MDM GUI programs to
+# automatically update with the new configuration. Not all configuration
+# options are supported by mdmsetup, so to modify some values it may be
+# necessary to modify this file directly by hand.
+#
+# This file overrides the default configuration settings. These settings
+# are stored in the MDM System Defaults configuration file, which is found
+# at the following location.
+#
+# /usr/share/mdm/defaults.conf.
+#
+# Default settings are first overriden by you distribution in /usr/share/mdm/distro.conf
+# and then by the settings present in this file.
+#
+# This file contains comments about the meaning of each configuration option,
+# so is also a useful reference. In short, to hand-edit
+# this file, simply add or modify the key=value combination in the
+# appropriate section in the template below this comment section.
+#
+# For example, if you want to specify a different value for the Enable key
+# in the "[debug]" section of your MDM System Defaults configuration file,
+# then add "Enable=true" in the "[debug]" section of this file.  If the
+# key already exists in this file, then simply modify it.
+#
+# If you hand edit a MDM configuration file, you can run the following
+# command and the MDM daemon will immediately reflect the change.  Any
+# running MDM GUI programs will also be notified to update with the new
+# configuration.
+#
+# mdmflexiserver --command="UPDATE_CONFIG <configuration key>"
+#
+# e.g, the "Enable" key in the "[debug]" section would be "debug/Enable".
+#
+# You can also run mdm-restart or mdm-safe-restart to cause MDM to restart and
+# re-read the new configuration settings.  You can also restart MDM by sending
+# a HUP or USR1 signal to the daemon.  HUP behaves like mdm-restart and causes
+# any user session started by MDM to exit immediately while USR1 behaves like
+# mdm-safe-restart and will wait until all users log out before restarting MDM.
+#
+#
+# NOTE: Lines that begin with "#" are considered comments.
+#
+# Have fun!
+
+[daemon]
+<% if @autologin %>
+AutomaticLoginEnable=true
+AutomaticLogin=<%= @autologin_user %>
+TimedLoginEnable=true
+TimedLogin=<%= @autologin_user %>
+TimedLoginDelay=<%= @autologin_timeout %>
+<% end %>
+
+[security]
+
+[xdmcp]
+
+[gui]
+
+[greeter]
+
+[chooser]
+
+[debug]
+
+# Note that to disable servers defined in the MDM System Defaults
+# configuration file (such as 0=Standard, you must put a line in this file
+# that says 0=inactive, as described in the Configuration section of the MDM
+# documentation.
+#
+[servers]
+
+# Also note, that if you redefine a [server-foo] section, then MDM will
+# use the definition in this file, not the MDM System Defaults configuration
+# file.  It is currently not possible to disable a [server-foo] section
+# defined in the MDM System Defaults configuration file.
+#


### PR DESCRIPTION
This policy allows you to select a display manager between two options: MDM or Lightdm.
In addition, you can set up an account for autologin.