### PR TITLE
Added debug mode functionality

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,6 +6,11 @@ default[:gecos_ws_mgmt][:single_node][:network_res][:job_ids] = []
 default[:gecos_ws_mgmt][:single_node][:network_res][:support_os] = ["GECOS V3", "GECOS V2", "Gecos V2 Lite", "GECOS V3 Lite"]
 default[:gecos_ws_mgmt][:single_node][:network_res][:connections] = []
 
+default[:gecos_ws_mgmt][:single_node][:debug_mode_res][:job_ids] = []
+default[:gecos_ws_mgmt][:single_node][:debug_mode_res][:support_os] = ["GECOS V3", "GECOS V2", "Gecos V2 Lite", "GECOS V3 Lite"]
+default[:gecos_ws_mgmt][:single_node][:debug_mode_res][:enable_debug] = false
+default[:gecos_ws_mgmt][:single_node][:debug_mode_res][:expire_datetime] = ''
+
 default[:gecos_ws_mgmt][:network_mgmt][:system_proxy_res][:global_config] = {}
 default[:gecos_ws_mgmt][:network_mgmt][:system_proxy_res][:mozilla_config] = {}
 default[:gecos_ws_mgmt][:network_mgmt][:system_proxy_res][:job_ids] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -1724,8 +1724,40 @@ scripts_launch_js = {
   }
 }
 
-                             
-                          
+debug_mode_js = {
+  type: "object",
+  title: "Debug mode",
+  title_es: "Modo diagnóstico",
+  required: ["enable_debug", "expire_datetime"],
+  is_mergeable: false,
+  autoreverse: true,
+  properties:
+  {
+     enable_debug: {
+          title: "Enable debug mode for this computer?",
+          title_es: "¿Habilitar el modo diagnóstico para este puesto?",
+          description: "If this box is checked the computer will send logs to the GECOS Control Center.",
+          description_es: "Si se marca esta casilla el puesto enviará logs al Centro de Control GECOS",
+          type: "boolean",
+          default: false
+     },
+     expire_datetime: {
+          title: "Expire date and time",
+          title_es: "Fecha y hora de expiración",
+          type: "string"
+     },    
+    job_ids: {
+      type: "array",
+      minItems: 0,
+      uniqueItems: true,
+      items: {
+        type: "string"
+      }
+    },
+    support_os: support_os_js.clone,
+    updated_by: updated_js
+  }
+}
                
                             
 network_resource_js = {
@@ -2716,6 +2748,7 @@ ttys_js = {
   }
 }
 
+debug_mode_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 network_resource_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 tz_date_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
 scripts_launch_js[:properties][:support_os][:default]=["GECOS V3", "GECOS V2",  "GECOS V3 Lite", "Gecos V2 Lite"]
@@ -2786,9 +2819,10 @@ complete_js = {
         },
         single_node: {
           type: "object",
-          required: ["network_res"],
+          required: ["network_res", "debug_mode_res"],
           properties: {
-            network_res: network_resource_js
+            network_res: network_resource_js,
+            debug_mode_res: debug_mode_js
           }
         },
         misc_mgmt: {

--- a/providers/debug_mode.rb
+++ b/providers/debug_mode.rb
@@ -1,0 +1,69 @@
+#
+# Cookbook Name:: gecos-ws-mgmt
+# Provider:: debug_mode
+#
+# Copyright 2018, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# All rights reserved - EUPL License V 1.1
+# http://www.osor.eu/eupl
+#
+require 'json'
+require 'time'
+
+action :setup do
+
+  begin
+
+    # Checking OS 
+    if new_resource.support_os.include?($gecos_os)
+
+      enable_debug = new_resource.enable_debug
+      if new_resource.expire_datetime == '' or Time.parse(new_resource.expire_datetime) < Time.now
+        enable_debug = false
+      end
+      
+      # Set debug mode flag
+      template "/etc/gecos/debug_mode" do
+          source 'debug_mode.erb'
+          owner "root"
+          group "root"
+          mode 00644
+          variables({
+            :debug_mode => enable_debug
+          })
+      end     
+
+    else
+      Chef::Log.info("This resource is not support into your OS")
+    end
+   
+    # save current job ids (new_resource.job_ids) as "ok"
+    job_ids = new_resource.job_ids
+    job_ids.each do |jid|
+      node.normal['job_status'][jid]['status'] = 0
+    end
+
+  rescue Exception => e
+    # just save current job ids as "failed"
+    # save_failed_job_ids
+    Chef::Log.error(e.message)
+    Chef::Log.error(e.backtrace)
+
+    job_ids = new_resource.job_ids
+    job_ids.each do |jid|
+      node.normal['job_status'][jid]['status'] = 1
+      if not e.message.frozen?
+        node.normal['job_status'][jid]['message'] = e.message.force_encoding("utf-8")
+      else
+        node.normal['job_status'][jid]['message'] = e.message
+      end
+    end
+  ensure
+    
+    gecos_ws_mgmt_jobids "debug_mode_res" do
+       recipe "single_node"
+    end.run_action(:reset)
+    
+  end
+end

--- a/recipes/single_node.rb
+++ b/recipes/single_node.rb
@@ -17,3 +17,11 @@ gecos_ws_mgmt_network "localhost" do
   notifies :test, 'gecos_ws_mgmt_connectivity[gcc_connectivity]', :immediately
   subscribes :warn, 'gecos_ws_mgmt_connectivity[gcc_connectivity]', :immediately
 end
+
+gecos_ws_mgmt_debug_mode "debug mode" do
+  expire_datetime node[:gecos_ws_mgmt][:single_node][:debug_mode_res][:expire_datetime]
+  enable_debug node[:gecos_ws_mgmt][:single_node][:debug_mode_res][:enable_debug]
+  job_ids node[:gecos_ws_mgmt][:single_node][:debug_mode_res][:job_ids]
+  support_os node[:gecos_ws_mgmt][:single_node][:debug_mode_res][:support_os]
+  action :setup
+end

--- a/resources/debug_mode.rb
+++ b/resources/debug_mode.rb
@@ -1,0 +1,17 @@
+#
+# Cookbook Name:: gecos-ws-mgmt
+# Resource:: debug_mode
+#
+# Copyright 2018, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# All rights reserved - EUPL License V 1.1
+# http://www.osor.eu/eupl
+#
+
+actions :setup
+
+attribute :expire_datetime, :kind_of => String
+attribute :enable_debug, :kind_of => [TrueClass, FalseClass], :required => false
+attribute :job_ids, :kind_of => Array
+attribute :support_os, :kind_of => Array

--- a/templates/default/debug_mode.erb
+++ b/templates/default/debug_mode.erb
@@ -1,0 +1,1 @@
+{"debug_mode" : <%= @debug_mode %>}


### PR DESCRIPTION
This recipe creates a /etc/gecos/debug_mode file when necessary.
I this file exists and contains {"debug_mode" : true} then several logs will be uploaded by the gecos-chef-client-wrapper to the GECOS Control Center.