### PR TITLE
Helper methods for determining whether a policy should be executed or not

### DIFF
--- a/libraries/Runnable.rb
+++ b/libraries/Runnable.rb
@@ -1,0 +1,53 @@
+#
+# Cookbook Name:: gecos-ws-mgmt
+# Runnable Helper
+#
+# Copyright 2019, Junta de Andalucia
+# http://www.juntadeandalucia.es/
+#
+# All rights reserved - EUPL License V 1.1
+# http://www.osor.eu/eupl
+#
+
+module Runnable
+  module Helper
+
+    require 'chef/cookbook/metadata'
+
+    COOKBOOK_NAME = "gecos_ws_mgmt".freeze
+    UPDATED = "updated_by".freeze
+    AUTOREVERSE = "autoreverse".freeze
+
+    $schema = nil
+    
+    def load_metadata
+      if $schema.nil?
+        cookbook_path = Chef::Config[:cookbook_path] + '/' + COOKBOOK_NAME
+        Chef::Log.debug("Runnable Helper :::  load_metadata - cookbook_path = #{cookbook_path}")
+        if File.exist?(File.join(cookbook_path, 'metadata.rb'))
+          metadata_file = File.join(cookbook_path, 'metadata.rb')
+        else 
+          metadata_file = File.join(cookbook_path, 'metadata.json')
+        end
+        metadata = Chef::Cookbook::Metadata.new
+        metadata.from_file(metadata_file)
+        $schema = metadata.attributes[:json_schema][:object][:properties][COOKBOOK_NAME.to_sym][:properties]
+      end
+    end
+
+    def has_applied_policy?(recipe, policy)
+      !node[COOKBOOK_NAME.to_sym][recipe.to_sym][policy.to_sym][UPDATED.to_sym].empty? rescue false
+    end
+
+    def is_autoreversible?(recipe, policy)
+      $schema[recipe.to_sym][:properties][policy.to_sym][AUTOREVERSE.to_sym] rescue false
+    end
+
+    def is_supported?
+      new_resource.support_os.include?($gecos_os)
+    end
+  end
+end
+
+Chef::Recipe.send(:include, Runnable::Helper)
+Chef::Provider.send(:include, Runnable::Helper)

--- a/libraries/Runnable.rb
+++ b/libraries/Runnable.rb
@@ -35,16 +35,21 @@ module Runnable
       end
     end
 
-    def has_applied_policy?(recipe, policy)
+    def is_policy_active?(recipe, policy)
       !node[COOKBOOK_NAME.to_sym][recipe.to_sym][policy.to_sym][UPDATED.to_sym].empty? rescue false
     end
 
-    def is_autoreversible?(recipe, policy)
+    def is_policy_autoreversible?(recipe, policy)
       $schema[recipe.to_sym][:properties][policy.to_sym][AUTOREVERSE.to_sym] rescue false
     end
 
-    def is_supported?
-      new_resource.support_os.include?($gecos_os)
+    def is_os_supported?
+      if new_resource.support_os.include?($gecos_os)
+        true
+      else
+	Chef::Log.info('This resource is not supported in your OS')
+	false
+      end
     end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ maintainer        'GECOS Team'
 maintainer_email  'gecos@guadalinex.org'
 license           'Apache 2.0'
 description       'Cookbook for GECOS Workstations management'
-version           '0.7.4'
+version           '0.7.5'
 
 depends 'apt'
 #depends 'compat_resource'

--- a/providers/appconfig_firefox.rb
+++ b/providers/appconfig_firefox.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('software_mgmt','appconfig_firefox_res') || \
-          is_autoreversible?('software_mgmt','appconfig_firefox_res')
+    if is_os_supported? &&
+      (is_policy_active?('software_mgmt','appconfig_firefox_res') ||
+       is_policy_autoreversible?('software_mgmt','appconfig_firefox_res'))
 	    
       unless new_resource.config_firefox.empty?
         Chef::Log.debug('appconfig_firefox - config_firefox: '\

--- a/providers/appconfig_firefox.rb
+++ b/providers/appconfig_firefox.rb
@@ -11,7 +11,11 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('software_mgmt','appconfig_firefox_res') || \
+          is_autoreversible?('software_mgmt','appconfig_firefox_res')
+	    
       unless new_resource.config_firefox.empty?
         Chef::Log.debug('appconfig_firefox - config_firefox: '\
             "#{new_resource.config_firefox}")
@@ -73,8 +77,6 @@ action :setup do
           only_if 'test -f /etc/firefox/proxy-prefs.js'
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/appconfig_java.rb
+++ b/providers/appconfig_java.rb
@@ -11,8 +11,12 @@
 action :setup do
   begin
     alternatives_cmd = 'update-alternatives'
-    if new_resource.support_os.include?($gecos_os) &&
-       !new_resource.config_java.empty?
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif (!new_resource.config_java.empty? && \
+          has_applied_policy?('software_mgmt','appconfig_java_res')) || \
+          is_autoreversible?('software_mgmt','appconfig_java_res')
+
       version = new_resource.config_java['version']
       plug_version = new_resource.config_java['plug_version']
       sec = new_resource.config_java['sec']
@@ -76,8 +80,6 @@ action :setup do
         action :nothing
         variables var_hash
       end.run_action(:create)
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/appconfig_java.rb
+++ b/providers/appconfig_java.rb
@@ -11,11 +11,10 @@
 action :setup do
   begin
     alternatives_cmd = 'update-alternatives'
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif (!new_resource.config_java.empty? && \
-          has_applied_policy?('software_mgmt','appconfig_java_res')) || \
-          is_autoreversible?('software_mgmt','appconfig_java_res')
+    if is_os_supported? &&
+      ((!new_resource.config_java.empty? &&
+        is_policy_active?('software_mgmt','appconfig_java_res')) ||
+        is_policy_autoreversible?('software_mgmt','appconfig_java_res'))
 
       version = new_resource.config_java['version']
       plug_version = new_resource.config_java['plug_version']

--- a/providers/appconfig_libreoffice.rb
+++ b/providers/appconfig_libreoffice.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('software_mgmt','appconfig_libreoffice_res') || \
-          is_autoreversible?('software_mgmt','appconfig_libreoffice_res')
+    if is_os_supported? &&
+      (is_policy_active?('software_mgmt','appconfig_libreoffice_res') ||
+       is_policy_autoreversible?('software_mgmt','appconfig_libreoffice_res'))
       unless new_resource.config_libreoffice.empty?
         app_update = new_resource.config_libreoffice['app_update']
 

--- a/providers/appconfig_libreoffice.rb
+++ b/providers/appconfig_libreoffice.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('software_mgmt','appconfig_libreoffice_res') || \
+          is_autoreversible?('software_mgmt','appconfig_libreoffice_res')
       unless new_resource.config_libreoffice.empty?
         app_update = new_resource.config_libreoffice['app_update']
 
@@ -27,8 +30,6 @@ action :setup do
           end.run_action(:run)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/appconfig_thunderbird.rb
+++ b/providers/appconfig_thunderbird.rb
@@ -11,8 +11,12 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os) &&
-       !new_resource.config_thunderbird.empty?
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif (!new_resource.config_thunderbird.empty? && \
+          has_applied_policy?('software_mgmt','appconfig_thunderbird_res')) || \
+          is_autoreversible?('software_mgmt','appconfig_thunderbird_res')
+	    
       Chef::Log.debug('appconfig_thunderbird.rb - config_thunderbird:'\
           " #{new_resource.config_thunderbird}")
       # Detecting installation directory
@@ -54,8 +58,6 @@ action :setup do
         to '/etc/thunderbird/proxy-prefs.js'
         only_if 'test -f /etc/thunderbird/proxy-prefs.js'
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/appconfig_thunderbird.rb
+++ b/providers/appconfig_thunderbird.rb
@@ -11,11 +11,10 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif (!new_resource.config_thunderbird.empty? && \
-          has_applied_policy?('software_mgmt','appconfig_thunderbird_res')) || \
-          is_autoreversible?('software_mgmt','appconfig_thunderbird_res')
+    if is_os_supported? &&
+      ((!new_resource.config_thunderbird.empty? && 
+       is_policy_active?('software_mgmt','appconfig_thunderbird_res')) ||
+       is_policy_autoreversible?('software_mgmt','appconfig_thunderbird_res'))
 	    
       Chef::Log.debug('appconfig_thunderbird.rb - config_thunderbird:'\
           " #{new_resource.config_thunderbird}")

--- a/providers/auto_updates.rb
+++ b/providers/auto_updates.rb
@@ -15,7 +15,10 @@ action :setup do
     onstop_update = new_resource.onstop_update
     days = new_resource.days || []
     date = new_resource.date || {}
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','auto_updates_res') || \
+          is_autoreversible?('misc_mgmt','auto_updates_res')
  
       # Install required packages
       $required_pkgs['auto_updates'].each do |pkg|
@@ -112,8 +115,6 @@ action :setup do
           action :nothing
         end.run_action(:delete)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # TODO: add script to init.d, both in start fucntion, on login

--- a/providers/auto_updates.rb
+++ b/providers/auto_updates.rb
@@ -15,10 +15,9 @@ action :setup do
     onstop_update = new_resource.onstop_update
     days = new_resource.days || []
     date = new_resource.date || {}
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','auto_updates_res') || \
-          is_autoreversible?('misc_mgmt','auto_updates_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','auto_updates_res') ||
+       is_policy_autoreversible?('misc_mgmt','auto_updates_res'))
  
       # Install required packages
       $required_pkgs['auto_updates'].each do |pkg|

--- a/providers/boot_lock.rb
+++ b/providers/boot_lock.rb
@@ -15,7 +15,11 @@ action :setup do
     unlock_user = new_resource.unlock_user
     unlock_pass = new_resource.unlock_pass
     grub_conf = '/boot/grub/grub.cfg'
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','boot_lock_res') || \
+          is_autoreversible?('misc_mgmt','boot_lock_res')
+    
       if ::File.file?(grub_conf)
         is_boot_locked = ::File.read(grub_conf).include? 'superusers'
         execute_update = (lock_boot != is_boot_locked)
@@ -64,8 +68,6 @@ action :setup do
       else
         Chef::Log.info('Boot lock status: change not needed')
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     job_ids = new_resource.job_ids

--- a/providers/boot_lock.rb
+++ b/providers/boot_lock.rb
@@ -15,10 +15,9 @@ action :setup do
     unlock_user = new_resource.unlock_user
     unlock_pass = new_resource.unlock_pass
     grub_conf = '/boot/grub/grub.cfg'
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','boot_lock_res') || \
-          is_autoreversible?('misc_mgmt','boot_lock_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','boot_lock_res') ||
+       is_policy_autoreversible?('misc_mgmt','boot_lock_res'))
     
       if ::File.file?(grub_conf)
         is_boot_locked = ::File.read(grub_conf).include? 'superusers'

--- a/providers/cert.rb
+++ b/providers/cert.rb
@@ -10,10 +10,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','cert_res') || \
-          is_autoreversible?('misc_mgmt','cert_res')	  
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','cert_res') ||
+       is_policy_autoreversible?('misc_mgmt','cert_res'))
       # install depends
       $required_pkgs['cert'].each do |pkg|
         Chef::Log.debug("cert.rb - REQUIRED PACKAGE = #{pkg}")

--- a/providers/cert.rb
+++ b/providers/cert.rb
@@ -10,7 +10,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','cert_res') || \
+          is_autoreversible?('misc_mgmt','cert_res')	  
       # install depends
       $required_pkgs['cert'].each do |pkg|
         Chef::Log.debug("cert.rb - REQUIRED PACKAGE = #{pkg}")
@@ -111,8 +114,6 @@ action :setup do
       else
         Chef::Log.error('Can\'t find /etc/ca-certificates.conf file!')
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/debug_mode.rb
+++ b/providers/debug_mode.rb
@@ -14,7 +14,10 @@ require 'time'
 action :setup do
   begin
     # Checking OS
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('single_node','debug_mode_res') || \
+          is_autoreversible?('single_node','debug_mode_res')
       enable_debug = new_resource.enable_debug
       if new_resource.expire_datetime == '' ||
          Time.parse(new_resource.expire_datetime) < Time.now
@@ -30,8 +33,6 @@ action :setup do
         mode '0644'
         variables var_hash
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/debug_mode.rb
+++ b/providers/debug_mode.rb
@@ -13,11 +13,9 @@ require 'time'
 
 action :setup do
   begin
-    # Checking OS
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('single_node','debug_mode_res') || \
-          is_autoreversible?('single_node','debug_mode_res')
+    if is_os_supported? &&
+      (is_policy_active?('single_node','debug_mode_res') ||
+       is_policy_autoreversible?('single_node','debug_mode_res'))
       enable_debug = new_resource.enable_debug
       if new_resource.expire_datetime == '' ||
          Time.parse(new_resource.expire_datetime) < Time.now

--- a/providers/desktop_background.rb
+++ b/providers/desktop_background.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','desktop_background_res') || \
-          is_autoreversible?('users_mgmt','desktop_background_res')	  
+    if is_os_supported &&
+      (is_policy_active?('users_mgmt','desktop_background_res') ||
+       is_policy_autoreversible?('users_mgmt','desktop_background_res'))
       $required_pkgs['desktop_background'].each do |pkg|
         Chef::Log.debug("desktop_background.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do

--- a/providers/desktop_background.rb
+++ b/providers/desktop_background.rb
@@ -11,7 +11,7 @@
 
 action :setup do
   begin
-    if is_os_supported &&
+    if is_os_supported? &&
       (is_policy_active?('users_mgmt','desktop_background_res') ||
        is_policy_autoreversible?('users_mgmt','desktop_background_res'))
       $required_pkgs['desktop_background'].each do |pkg|

--- a/providers/desktop_background.rb
+++ b/providers/desktop_background.rb
@@ -11,14 +11,16 @@
 
 action :setup do
   begin
-    $required_pkgs['desktop_background'].each do |pkg|
-      Chef::Log.debug("desktop_background.rb - REQUIRED PACKAGE = #{pkg}")
-      package pkg do
-        action :nothing
-      end.run_action(:install)
-    end
-
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','desktop_background_res') || \
+          is_autoreversible?('users_mgmt','desktop_background_res')	  
+      $required_pkgs['desktop_background'].each do |pkg|
+        Chef::Log.debug("desktop_background.rb - REQUIRED PACKAGE = #{pkg}")
+        package pkg do
+          action :nothing
+        end.run_action(:install)
+      end
 
       if !new_resource.users.nil? && !new_resource.users.empty?
         users = new_resource.users
@@ -44,8 +46,6 @@ action :setup do
           end.run_action(:set)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
     # save current job ids (new_resource.job_ids) as "ok"
     job_ids = new_resource.job_ids

--- a/providers/display_manager.rb
+++ b/providers/display_manager.rb
@@ -16,7 +16,11 @@ CURRENT_DISPLAY_MANAGER = ::File.basename(
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os) && !new_resource.dm.empty?
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif (!new_resource.dm.empty? && \
+          has_applied_policy?('software_mgmt','display_manager_res')) || \
+          is_autoreversible?('software_mgmt','display_manager_res')
 
       # Template variables
       var_hash = {
@@ -146,8 +150,6 @@ action :setup do
         not_if "#{new_resource.autologin} && "\
           "! getent passwd #{new_resource.autologin_options['username']}"
       end
-    else
-      Chef::Log.info('Policy is not compatible with this operative system')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/display_manager.rb
+++ b/providers/display_manager.rb
@@ -16,11 +16,10 @@ CURRENT_DISPLAY_MANAGER = ::File.basename(
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif (!new_resource.dm.empty? && \
-          has_applied_policy?('software_mgmt','display_manager_res')) || \
-          is_autoreversible?('software_mgmt','display_manager_res')
+    if is_os_supported? &&
+      ((!new_resource.dm.empty? &&
+        is_policy_active?('software_mgmt','display_manager_res')) ||
+        is_policy_autoreversible?('software_mgmt','display_manager_res'))
 
       # Template variables
       var_hash = {

--- a/providers/email_setup.rb
+++ b/providers/email_setup.rb
@@ -67,7 +67,10 @@ end
 action :setup do
   begin
     # Checking OS and Thunderbird
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','email_setup_res') || \
+          is_autoreversible?('users_mgmt','email_setup_res')
       # Setup email for users
       users = new_resource.users
       users.each_key do |user_key|
@@ -273,8 +276,6 @@ action :setup do
           action :nothing
         end.run_action(:run)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/email_setup.rb
+++ b/providers/email_setup.rb
@@ -66,11 +66,9 @@ end
 
 action :setup do
   begin
-    # Checking OS and Thunderbird
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','email_setup_res') || \
-          is_autoreversible?('users_mgmt','email_setup_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','email_setup_res') ||
+       is_policy_autoreversible?('users_mgmt','email_setup_res'))
       # Setup email for users
       users = new_resource.users
       users.each_key do |user_key|

--- a/providers/file_browser.rb
+++ b/providers/file_browser.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','file_browser_res') || \
+          is_autoreversible?('users_mgmt','file_browser_res')
       users = new_resource.users
       users.each_key do |user_key|
         nameuser = user_key
@@ -75,8 +78,6 @@ action :setup do
           action :nothing
         end.run_action(:set)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as 'ok'

--- a/providers/file_browser.rb
+++ b/providers/file_browser.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','file_browser_res') || \
-          is_autoreversible?('users_mgmt','file_browser_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','file_browser_res') ||
+       is_policy_autoreversible?('users_mgmt','file_browser_res'))
       users = new_resource.users
       users.each_key do |user_key|
         nameuser = user_key

--- a/providers/folder_sharing.rb
+++ b/providers/folder_sharing.rb
@@ -10,7 +10,10 @@
 #
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','folder_sharing_res') || \
+          is_autoreversible?('users_mgmt','folder_sharing_res')
       require 'etc'
 
       users = new_resource.users
@@ -56,8 +59,6 @@ action :setup do
       job_ids.each do |jid|
         node.normal['job_status'][jid]['status'] = 0
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
   rescue StandardError => e
     # just save current job ids as "failed"

--- a/providers/folder_sharing.rb
+++ b/providers/folder_sharing.rb
@@ -10,10 +10,9 @@
 #
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','folder_sharing_res') || \
-          is_autoreversible?('users_mgmt','folder_sharing_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','folder_sharing_res') ||
+       is_policy_autoreversible?('users_mgmt','folder_sharing_res'))
       require 'etc'
 
       users = new_resource.users

--- a/providers/folder_sync.rb
+++ b/providers/folder_sync.rb
@@ -10,7 +10,10 @@
 #
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','folder_sync_res') || \
+          is_autoreversible?('users_mgmt','folder_sync_res')
       users = new_resource.users
 
       $required_pkgs['folder_sync'].each do |pkg|
@@ -106,8 +109,6 @@ action :setup do
           variables var_hash
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/folder_sync.rb
+++ b/providers/folder_sync.rb
@@ -10,10 +10,9 @@
 #
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','folder_sync_res') || \
-          is_autoreversible?('users_mgmt','folder_sync_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','folder_sync_res') || \
+       is_policy_autoreversible?('users_mgmt','folder_sync_res'))
       users = new_resource.users
 
       $required_pkgs['folder_sync'].each do |pkg|

--- a/providers/forticlientvpn.rb
+++ b/providers/forticlientvpn.rb
@@ -13,8 +13,12 @@ HISTORY_FILTER = /^profile|^p12passwd|^path|^password|^user|^port|^server/
 action :setup do
   begin
     # Added check to avoid execution if no connections defined
-    if new_resource.support_os.include?($gecos_os) &&
-       !new_resource.connections.nil? && !new_resource.connections.empty?
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif (!new_resource.connections.nil? && \
+	   !new_resource.connections.empty? && \
+           has_applied_policy?('network_mgmt','forticlientvpn_res')) || \
+           is_autoreversible?('network_mgmt','forticlientvpn_res')
 
       res_proxyserver = new_resource.proxyserver || node[:gecos_ws_mgmt][
         :network_mgmt][:forticlientvpn_res][:proxyserver]
@@ -101,8 +105,6 @@ action :setup do
           variables var_hash
         end
       end
-    elsif !new_resource.support_os.include?($gecos_os)
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/forticlientvpn.rb
+++ b/providers/forticlientvpn.rb
@@ -13,12 +13,11 @@ HISTORY_FILTER = /^profile|^p12passwd|^path|^password|^user|^port|^server/
 action :setup do
   begin
     # Added check to avoid execution if no connections defined
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif (!new_resource.connections.nil? && \
-	   !new_resource.connections.empty? && \
-           has_applied_policy?('network_mgmt','forticlientvpn_res')) || \
-           is_autoreversible?('network_mgmt','forticlientvpn_res')
+    if is_os_supported? &&
+      ((!new_resource.connections.nil? &&
+        !new_resource.connections.empty? &&
+        is_policy_active?('network_mgmt','forticlientvpn_res')) ||
+        is_policy_autoreversible?('network_mgmt','forticlientvpn_res'))
 
       res_proxyserver = new_resource.proxyserver || node[:gecos_ws_mgmt][
         :network_mgmt][:forticlientvpn_res][:proxyserver]

--- a/providers/idle_timeout.rb
+++ b/providers/idle_timeout.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','idle_timeout_res') || \
+          is_autoreversible?('users_mgmt','idle_timeout_res')
       $required_pkgs['idle_timeout'].each do |pkg|
         Chef::Log.debug("idle_timeout.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do
@@ -78,8 +81,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/idle_timeout.rb
+++ b/providers/idle_timeout.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','idle_timeout_res') || \
-          is_autoreversible?('users_mgmt','idle_timeout_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','idle_timeout_res') ||
+       is_policy_autoreversible?('users_mgmt','idle_timeout_res'))
       $required_pkgs['idle_timeout'].each do |pkg|
         Chef::Log.debug("idle_timeout.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do

--- a/providers/im_client.rb
+++ b/providers/im_client.rb
@@ -111,7 +111,10 @@ end
 action :setup do
   begin
     # Checking OS and Pidgin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','im_client_res') || \
+          is_autoreversible?('users_mgmt','im_client_res')
       # Install required packages
       $required_pkgs['im_client'].each do |pkg|
         Chef::Log.debug("im_client.rb - REQUIRED PACKAGES = #{pkg}")
@@ -246,8 +249,6 @@ action :setup do
           end
         end.run_action(:create)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/im_client.rb
+++ b/providers/im_client.rb
@@ -111,10 +111,9 @@ end
 action :setup do
   begin
     # Checking OS and Pidgin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','im_client_res') || \
-          is_autoreversible?('users_mgmt','im_client_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','im_client_res') ||
+       is_policy_autoreversible?('users_mgmt','im_client_res'))
       # Install required packages
       $required_pkgs['im_client'].each do |pkg|
         Chef::Log.debug("im_client.rb - REQUIRED PACKAGES = #{pkg}")

--- a/providers/local_admin_users.rb
+++ b/providers/local_admin_users.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','local_admin_users_res') || \
-          is_autoreversible?('misc_mgmt','local_admin_users_res')
+    if is_os_supported? &&
+       (is_policy_active?('misc_mgmt','local_admin_users_res') ||
+        is_policy_autoreversible?('misc_mgmt','local_admin_users_res'))
       local_admin_list = new_resource.local_admin_list
       local_admin_list.each do |admin|
         case admin.action

--- a/providers/local_admin_users.rb
+++ b/providers/local_admin_users.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','local_admin_users_res') || \
+          is_autoreversible?('misc_mgmt','local_admin_users_res')
       local_admin_list = new_resource.local_admin_list
       local_admin_list.each do |admin|
         case admin.action
@@ -34,8 +37,6 @@ action :setup do
           "(#{admin.action})"
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
     # save current job ids (new_resource.job_ids) as "ok"
     job_ids = new_resource.job_ids

--- a/providers/local_file.rb
+++ b/providers/local_file.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','local_file_res') || \
-          is_autoreversible?('misc_mgmt','local_file_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','local_file_res') ||
+       is_policy_autoreversible?('misc_mgmt','local_file_res'))
       localfiles = new_resource.localfiles
 
       Chef::Log.debug("local_file.rb ::: localfiles = #{localfiles}")

--- a/providers/local_file.rb
+++ b/providers/local_file.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','local_file_res') || \
+          is_autoreversible?('misc_mgmt','local_file_res')
       localfiles = new_resource.localfiles
 
       Chef::Log.debug("local_file.rb ::: localfiles = #{localfiles}")
@@ -76,8 +79,6 @@ action :setup do
           end.run_action(:delete)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/local_groups.rb
+++ b/providers/local_groups.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','local_groups_res') || \
-          is_autoreversible?('misc_mgmt','local_groups_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','local_groups_res') ||
+       is_policy_autoreversible?('misc_mgmt','local_groups_res'))
       groups_list = new_resource.groups_list
 
       groups_list.each do |item|

--- a/providers/local_groups.rb
+++ b/providers/local_groups.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','local_groups_res') || \
+          is_autoreversible?('misc_mgmt','local_groups_res')
       groups_list = new_resource.groups_list
 
       groups_list.each do |item|
@@ -32,8 +35,6 @@ action :setup do
           end.run_action(:modify)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/local_users.rb
+++ b/providers/local_users.rb
@@ -10,10 +10,9 @@
 #
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','local_users_res') || \
-          is_autoreversible?('misc_mgmt','local_users_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','local_users_res') ||
+       is_policy_autoreversible?('misc_mgmt','local_users_res'))
       require 'etc'
 
       $required_pkgs['local_users'].each do |pkg|

--- a/providers/local_users.rb
+++ b/providers/local_users.rb
@@ -10,7 +10,10 @@
 #
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','local_users_res') || \
+          is_autoreversible?('misc_mgmt','local_users_res')
       require 'etc'
 
       $required_pkgs['local_users'].each do |pkg|
@@ -53,8 +56,6 @@ action :setup do
           end.run_action(:run)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/mimetypes.rb
+++ b/providers/mimetypes.rb
@@ -16,10 +16,9 @@ DEFAULT_SECTION = 'Default Applications'.freeze
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','mimetypes_res') || \
-          is_autoreversible?('users_mgmt','mimetypes_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','mimetypes_res') ||
+       is_policy_autoreversible?('users_mgmt','mimetypes_res'))
       $required_pkgs['mimetypes'].each do |pkg|
         Chef::Log.debug("mimetypes.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do

--- a/providers/mimetypes.rb
+++ b/providers/mimetypes.rb
@@ -16,7 +16,10 @@ DEFAULT_SECTION = 'Default Applications'.freeze
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','mimetypes_res') || \
+          is_autoreversible?('users_mgmt','mimetypes_res')
       $required_pkgs['mimetypes'].each do |pkg|
         Chef::Log.debug("mimetypes.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do
@@ -103,8 +106,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     job_ids = new_resource.job_ids

--- a/providers/mobile_broadband.rb
+++ b/providers/mobile_broadband.rb
@@ -12,10 +12,9 @@
 action :setup do
   begin
     # setup resource depends
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('network_mgmt','mobile_broadband_res') || \
-          is_autoreversible?('network_mgmt','mobile_broadband_res')
+    if is_os_supported? &&
+      (is_policy_active?('network_mgmt','mobile_broadband_res') ||
+       is_policy_autoreversible?('network_mgmt','mobile_broadband_res'))
       gem_depends = %w[activesupport json]
       gem_depends.each do |gem|
         r = gem_package gem do

--- a/providers/mobile_broadband.rb
+++ b/providers/mobile_broadband.rb
@@ -12,7 +12,10 @@
 action :setup do
   begin
     # setup resource depends
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('network_mgmt','mobile_broadband_res') || \
+          is_autoreversible?('network_mgmt','mobile_broadband_res')
       gem_depends = %w[activesupport json]
       gem_depends.each do |gem|
         r = gem_package gem do
@@ -105,8 +108,6 @@ action :setup do
       job_ids.each do |jid|
         node.normal['job_status'][jid]['status'] = 0
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
   rescue StandardError => e
     # just save current job ids as "failed"

--- a/providers/network.rb
+++ b/providers/network.rb
@@ -21,10 +21,9 @@ nochanges = true
 action :presetup do
   begin
     Chef::Log.info('network.rb ::: Starting PRESETUP ...')
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('network_mgmt','network_res') || \
-          is_autoreversible?('network_mgmt','network_res')
+    if is_os_supported? &&
+      (is_policy_active?('network_mgmt','network_res') ||
+       is_policy_autoreversible?('network_mgmt','network_res'))
       connections = new_resource.connections
       interfaces = node[:network][:interfaces]
 

--- a/providers/network.rb
+++ b/providers/network.rb
@@ -21,7 +21,10 @@ nochanges = true
 action :presetup do
   begin
     Chef::Log.info('network.rb ::: Starting PRESETUP ...')
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('network_mgmt','network_res') || \
+          is_autoreversible?('network_mgmt','network_res')
       connections = new_resource.connections
       interfaces = node[:network][:interfaces]
 
@@ -75,8 +78,6 @@ action :presetup do
         end.run_action(:backup)
         action_setup
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
   rescue StandardError => e
     Chef::Log.error(e.message)

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -75,10 +75,9 @@ end
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('software_mgmt','package_res') || \
-          is_autoreversible?('software_mgmt','package_res')
+    if is_os_supported? &&
+      (is_policy_active?('software_mgmt','package_res') ||
+       is_policy_autoreversible?('software_mgmt','package_res'))
       if new_resource.package_list.any?
         Chef::Log.info('Installing package list')
         new_resource.package_list.each do |pkg|

--- a/providers/package.rb
+++ b/providers/package.rb
@@ -75,7 +75,10 @@ end
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('software_mgmt','package_res') || \
+          is_autoreversible?('software_mgmt','package_res')
       if new_resource.package_list.any?
         Chef::Log.info('Installing package list')
         new_resource.package_list.each do |pkg|
@@ -113,8 +116,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/power_conf.rb
+++ b/providers/power_conf.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','power_conf_res') || \
-          is_autoreversible?('misc_mgmt','power_conf_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','power_conf_res') ||
+       is_policy_autoreversible?('misc_mgmt','power_conf_res'))
       require 'time'
 
       $required_pkgs['power_conf'].each do |pkg|

--- a/providers/power_conf.rb
+++ b/providers/power_conf.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','power_conf_res') || \
+          is_autoreversible?('misc_mgmt','power_conf_res')
       require 'time'
 
       $required_pkgs['power_conf'].each do |pkg|
@@ -94,8 +97,6 @@ action :setup do
           end.run_action(:run)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/printers.rb
+++ b/providers/printers.rb
@@ -116,10 +116,9 @@ end
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('printers_mgmt','printers_res') || \
-          is_autoreversible?('printers_mgmt','printers_res')
+    if is_os_supported? &&
+      (is_policy_active?('printers_mgmt','printers_res') || \
+       is_policy_autoreversible?('printers_mgmt','printers_res'))
       printers_list = new_resource.printers_list
 
       if printers_list.any?

--- a/providers/remote_control.rb
+++ b/providers/remote_control.rb
@@ -13,11 +13,9 @@ require 'time'
 
 action :setup do
   begin
-    # Checking OS
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','remote_control_res') || \
-          is_autoreversible?('misc_mgmt','remote_control_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','remote_control_res') ||
+       is_policy_autoreversible?('misc_mgmt','remote_control_res'))
 
       enable_helpchannel = new_resource.enable_helpchannel
       enable_ssh = new_resource.enable_ssh

--- a/providers/remote_control.rb
+++ b/providers/remote_control.rb
@@ -14,7 +14,10 @@ require 'time'
 action :setup do
   begin
     # Checking OS
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','remote_control_res') || \
+          is_autoreversible?('misc_mgmt','remote_control_res')
 
       enable_helpchannel = new_resource.enable_helpchannel
       enable_ssh = new_resource.enable_ssh
@@ -66,8 +69,6 @@ action :setup do
         variables var_hash
 	only_if { enable_helpchannel && !tunnel_url.empty? }
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/remote_shutdown.rb
+++ b/providers/remote_shutdown.rb
@@ -12,7 +12,10 @@ require 'date'
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','remote_shutdown_res') || \
+          is_autoreversible?('misc_mgmt','remote_shutdown_res')
       if !new_resource.shutdown_mode.empty?
         shutdown_command = if new_resource.shutdown_mode == 'halt'
                              '/sbin/shutdown -r now'
@@ -61,8 +64,6 @@ action :setup do
           action :nothing
         end.run_action(:delete)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/remote_shutdown.rb
+++ b/providers/remote_shutdown.rb
@@ -12,10 +12,9 @@ require 'date'
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','remote_shutdown_res') || \
-          is_autoreversible?('misc_mgmt','remote_shutdown_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','remote_shutdown_res') || \
+       is_policy_autoreversible?('misc_mgmt','remote_shutdown_res'))
       if !new_resource.shutdown_mode.empty?
         shutdown_command = if new_resource.shutdown_mode == 'halt'
                              '/sbin/shutdown -r now'

--- a/providers/screensaver.rb
+++ b/providers/screensaver.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','screensaver_res') || \
+          is_autoreversible?('users_mgmt','screensaver_res')
       users = new_resource.users
       users.each_key do |user_key|
         nameuser = user_key
@@ -62,8 +65,6 @@ action :setup do
           action :nothing
         end.run_action(:set)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as 'ok'

--- a/providers/screensaver.rb
+++ b/providers/screensaver.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','screensaver_res') || \
-          is_autoreversible?('users_mgmt','screensaver_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','screensaver_res') ||
+       is_policy_autoreversible?('users_mgmt','screensaver_res'))
       users = new_resource.users
       users.each_key do |user_key|
         nameuser = user_key

--- a/providers/scripts_launch.rb
+++ b/providers/scripts_launch.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','scripts_launch_res') || \
+          is_autoreversible?('misc_mgmt','scripts_launch_res')
       on_startup = new_resource.on_startup.select do |script|
         ::File.exist?(script) && ::File.executable?(script)
       end
@@ -71,8 +74,6 @@ action :setup do
           action :nothing
         end.run_action(:delete)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/scripts_launch.rb
+++ b/providers/scripts_launch.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','scripts_launch_res') || \
-          is_autoreversible?('misc_mgmt','scripts_launch_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','scripts_launch_res') ||
+       is_policy_autoreversible?('misc_mgmt','scripts_launch_res'))
       on_startup = new_resource.on_startup.select do |script|
         ::File.exist?(script) && ::File.executable?(script)
       end

--- a/providers/shutdown_options.rb
+++ b/providers/shutdown_options.rb
@@ -13,10 +13,9 @@ GRP_POWER = 'power'.freeze
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','shutdown_options_res') || \
-          is_autoreversible?('users_mgmt','shutdown_options_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','shutdown_options_res') ||
+       is_policy_autoreversible?('users_mgmt','shutdown_options_res'))
       $required_pkgs['shutdown_options'].each do |pkg|
         Chef::Log.debug("shutdown_options.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do

--- a/providers/shutdown_options.rb
+++ b/providers/shutdown_options.rb
@@ -14,6 +14,10 @@ GRP_POWER = 'power'.freeze
 action :setup do
   begin
     if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','shutdown_options_res') || \
+          is_autoreversible?('users_mgmt','shutdown_options_res')
       $required_pkgs['shutdown_options'].each do |pkg|
         Chef::Log.debug("shutdown_options.rb - REQUIRED PACKAGE = #{pkg}")
         package pkg do
@@ -69,8 +73,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/shutdown_options.rb
+++ b/providers/shutdown_options.rb
@@ -13,7 +13,6 @@ GRP_POWER = 'power'.freeze
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
     if !is_supported?
       Chef::Log.info('This resource is not supported in your OS')
     elsif has_applied_policy?('users_mgmt','shutdown_options_res') || \

--- a/providers/software_sources.rb
+++ b/providers/software_sources.rb
@@ -51,7 +51,10 @@ end
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('software_mgmt','software_sources_res') || \
+          is_autoreversible?('software_mgmt','_software_sources_res')
       repo_list = new_resource.repo_list
 
       current_lists = []
@@ -147,8 +150,6 @@ action :setup do
       files_to_remove.each do |value|
         ::File.delete("/etc/apt/sources.list.d/#{value}")
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/software_sources.rb
+++ b/providers/software_sources.rb
@@ -51,10 +51,9 @@ end
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('software_mgmt','software_sources_res') || \
-          is_autoreversible?('software_mgmt','_software_sources_res')
+    if is_os_supported? &&
+      (is_policy_active?('software_mgmt','software_sources_res') ||
+       is_policy_autoreversible?('software_mgmt','_software_sources_res'))
       repo_list = new_resource.repo_list
 
       current_lists = []

--- a/providers/system_proxy.rb
+++ b/providers/system_proxy.rb
@@ -77,7 +77,10 @@ action :presetup do
   begin
     Chef::Log.info('system_proxy.rb ::: Starting PRESETUP ...')
 
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('network_mgmt','system_proxy_res') || \
+          is_autoreversible?('network_mgmt','system_proxy_res')
       Chef::Log.info('system_proxy.rb ::: new_resource.global_config :'\
           "#{new_resource.global_config}")
       Chef::Log.info('system_proxy.rb ::: new_resource.mozilla_config:'\
@@ -267,8 +270,6 @@ action :presetup do
         Chef::Log.info('system_proxy.rb ::: Changes applied!')
       end
 
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
   rescue StandardError => e
     # just save current job ids as "failed"

--- a/providers/system_proxy.rb
+++ b/providers/system_proxy.rb
@@ -77,10 +77,9 @@ action :presetup do
   begin
     Chef::Log.info('system_proxy.rb ::: Starting PRESETUP ...')
 
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('network_mgmt','system_proxy_res') || \
-          is_autoreversible?('network_mgmt','system_proxy_res')
+    if is_os_supported? &&
+      (is_policy_active?('network_mgmt','system_proxy_res') ||
+       is_policy_autoreversible?('network_mgmt','system_proxy_res'))
       Chef::Log.info('system_proxy.rb ::: new_resource.global_config :'\
           "#{new_resource.global_config}")
       Chef::Log.info('system_proxy.rb ::: new_resource.mozilla_config:'\

--- a/providers/ttys.rb
+++ b/providers/ttys.rb
@@ -18,10 +18,9 @@ logind_conf = '/etc/systemd/logind.conf'
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','ttys_res') || \
-          is_autoreversible?('misc_mgmt','ttys_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','ttys_res') ||
+       is_policy_autoreversible?('misc_mgmt','ttys_res'))
       Chef::Log.debug("disable_ttys: #{new_resource.disable_ttys}")
 
       if new_resource.disable_ttys # DISABLE TTYs

--- a/providers/ttys.rb
+++ b/providers/ttys.rb
@@ -18,7 +18,10 @@ logind_conf = '/etc/systemd/logind.conf'
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','ttys_res') || \
+          is_autoreversible?('misc_mgmt','ttys_res')
       Chef::Log.debug("disable_ttys: #{new_resource.disable_ttys}")
 
       if new_resource.disable_ttys # DISABLE TTYs
@@ -120,8 +123,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
   rescue StandardError => e
     # just save current job ids as "failed"

--- a/providers/tz_date.rb
+++ b/providers/tz_date.rb
@@ -13,10 +13,9 @@ V2 = ['GECOS V2', 'Gecos V2 Lite'].freeze
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('misc_mgmt','tz_date_res') || \
-          is_autoreversible?('misc_mgmt','tz_date_res')
+    if is_os_supported? &&
+      (is_policy_active?('misc_mgmt','tz_date_res') ||
+       is_policy_autoreversible?('misc_mgmt','tz_date_res'))
 
       ntp_server = new_resource.server
 

--- a/providers/tz_date.rb
+++ b/providers/tz_date.rb
@@ -13,7 +13,10 @@ V2 = ['GECOS V2', 'Gecos V2 Lite'].freeze
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('misc_mgmt','tz_date_res') || \
+          is_autoreversible?('misc_mgmt','tz_date_res')
 
       ntp_server = new_resource.server
 
@@ -74,9 +77,6 @@ action :setup do
         end
 
       end # END CASE
-
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/user_alerts.rb
+++ b/providers/user_alerts.rb
@@ -13,7 +13,6 @@ require 'json'
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
     if !is_supported?
       Chef::Log.info('This resource is not supported in your OS')
     elsif has_applied_policy?('users_mgmt','user_alerts_res') || \

--- a/providers/user_alerts.rb
+++ b/providers/user_alerts.rb
@@ -14,6 +14,10 @@ require 'json'
 action :setup do
   begin
     if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','user_alerts_res') || \
+          is_autoreversible?('users_mgmt','user_alerts_res')
       # Installs the notify-send command
       $required_pkgs['user_alerts'].each do |pkg|
         Chef::Log.debug("user_alerts.rb - REQUIRED PACKAGE = #{pkg}")
@@ -78,8 +82,6 @@ action :setup do
           action :nothing
         end.run_action(:delete)
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/user_alerts.rb
+++ b/providers/user_alerts.rb
@@ -13,10 +13,9 @@ require 'json'
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','user_alerts_res') || \
-          is_autoreversible?('users_mgmt','user_alerts_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','user_alerts_res') ||
+       is_policy_autoreversible?('users_mgmt','user_alerts_res'))
       # Installs the notify-send command
       $required_pkgs['user_alerts'].each do |pkg|
         Chef::Log.debug("user_alerts.rb - REQUIRED PACKAGE = #{pkg}")

--- a/providers/user_apps_autostart.rb
+++ b/providers/user_apps_autostart.rb
@@ -10,7 +10,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','user_apps_autostart_res') || \
+          is_autoreversible?('users_mgmt','user_apps_autostart_res')
       users = new_resource.users
 
       case node['platform']
@@ -68,8 +71,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/user_apps_autostart.rb
+++ b/providers/user_apps_autostart.rb
@@ -10,10 +10,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','user_apps_autostart_res') || \
-          is_autoreversible?('users_mgmt','user_apps_autostart_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','user_apps_autostart_res') ||
+       is_policy_autoreversible?('users_mgmt','user_apps_autostart_res'))
       users = new_resource.users
 
       case node['platform']

--- a/providers/user_launchers.rb
+++ b/providers/user_launchers.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','user_launchers_res') || \
+          is_autoreversible?('users_mgmt','user_launchers_res')
       users = new_resource.users
 
       case node['platform']
@@ -71,8 +74,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/user_launchers.rb
+++ b/providers/user_launchers.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','user_launchers_res') || \
-          is_autoreversible?('users_mgmt','user_launchers_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','user_launchers_res') ||
+       is_policy_autoreversible?('users_mgmt','user_launchers_res'))
       users = new_resource.users
 
       case node['platform']

--- a/providers/user_modify_nm.rb
+++ b/providers/user_modify_nm.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','user_modify_nm_res') || \
-          is_autoreversible?('users_mgmt','user_modify_nm_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','user_modify_nm_res') ||
+       is_policy_autoreversible?('users_mgmt','user_modify_nm_res'))
       udisk_policy = '/var/lib/polkit-1/localauthority/50-local.d/'\
         '.freedesktop.NetworkManager.pkla'
 

--- a/providers/user_modify_nm.rb
+++ b/providers/user_modify_nm.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','user_modify_nm_res') || \
+          is_autoreversible?('users_mgmt','user_modify_nm_res')
       udisk_policy = '/var/lib/polkit-1/localauthority/50-local.d/'\
         '.freedesktop.NetworkManager.pkla'
 
@@ -42,8 +45,6 @@ action :setup do
           end.run_action(:modify)
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/user_mount.rb
+++ b/providers/user_mount.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','user_mount_res') || \
+          is_autoreversible?('users_mgmt','user_mount_res')
       userslist = new_resource.users
 
       udisk_policy = '/usr/share/polkit-1/actions/org.freedesktop.'\
@@ -59,8 +62,6 @@ action :setup do
         variables user_mount: usersm
         action :nothing
       end.run_action(:create)
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/user_mount.rb
+++ b/providers/user_mount.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','user_mount_res') || \
-          is_autoreversible?('users_mgmt','user_mount_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','user_mount_res') ||
+       is_policy_autoreversible?('users_mgmt','user_mount_res'))
       userslist = new_resource.users
 
       udisk_policy = '/usr/share/polkit-1/actions/org.freedesktop.'\

--- a/providers/user_shared_folders.rb
+++ b/providers/user_shared_folders.rb
@@ -11,10 +11,9 @@
 
 action :setup do
   begin
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif has_applied_policy?('users_mgmt','user_shared_folders_res') || \
-          is_autoreversible?('users_mgmt','user_shared_folders_res')
+    if is_os_supported? &&
+      (is_policy_active?('users_mgmt','user_shared_folders_res') ||
+       is_policy_autoreversible?('users_mgmt','user_shared_folders_res'))
       pattern = '(smb|nfs|ftp|sftp|dav)(:\/\/)([\S]*\/.*)'
       users = new_resource.users
       users.each_key do |user_key|

--- a/providers/user_shared_folders.rb
+++ b/providers/user_shared_folders.rb
@@ -11,7 +11,10 @@
 
 action :setup do
   begin
-    if new_resource.support_os.include?($gecos_os)
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif has_applied_policy?('users_mgmt','user_shared_folders_res') || \
+          is_autoreversible?('users_mgmt','user_shared_folders_res')
       pattern = '(smb|nfs|ftp|sftp|dav)(:\/\/)([\S]*\/.*)'
       users = new_resource.users
       users.each_key do |user_key|
@@ -79,8 +82,6 @@ action :setup do
           tmp_file.write_file
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
 
     # save current job ids (new_resource.job_ids) as "ok"

--- a/providers/web_browser.rb
+++ b/providers/web_browser.rb
@@ -12,11 +12,10 @@
 action :setup do
   begin
     ffx = ShellUtil.shell('apt-cache policy firefox').exitstatus
-    if !is_supported?
-      Chef::Log.info('This resource is not supported in your OS')
-    elsif (ffx && \
-          has_applied_policy?('users_mgmt','web_browser_res')) || \
-          is_autoreversible?('users_mgmt','web_browser_res')
+    if is_os_supported? &&
+      ((ffx &&
+        is_policy_active?('users_mgmt','web_browser_res')) ||
+        is_policy_autoreversible?('users_mgmt','web_browser_res'))
 
       $required_pkgs['web_browser'].each do |pkg|
         Chef::Log.debug("web_browser.rb - REQUIRED PACKAGES = #{pkg}")

--- a/providers/web_browser.rb
+++ b/providers/web_browser.rb
@@ -12,7 +12,11 @@
 action :setup do
   begin
     ffx = ShellUtil.shell('apt-cache policy firefox').exitstatus
-    if new_resource.support_os.include?($gecos_os) && ffx
+    if !is_supported?
+      Chef::Log.info('This resource is not supported in your OS')
+    elsif (ffx && \
+          has_applied_policy?('users_mgmt','web_browser_res')) || \
+          is_autoreversible?('users_mgmt','web_browser_res')
 
       $required_pkgs['web_browser'].each do |pkg|
         Chef::Log.debug("web_browser.rb - REQUIRED PACKAGES = #{pkg}")
@@ -307,8 +311,6 @@ action :setup do
           end
         end
       end
-    else
-      Chef::Log.info('This resource is not supported in your OS')
     end
     # save current job ids (new_resource.job_ids) as "ok"
     job_ids = new_resource.job_ids

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -71,3 +71,6 @@ include_recipe 'gecos_ws_mgmt::single_node'
 
 node.normal['use_node'] = {}
 node.override['gcc_link'] = true
+
+# Loading metadata (json-schema)
+load_metadata


### PR DESCRIPTION
It is not always possible to tell from the policy attributes whether a policy should be run or not, so new methods have been developed to ascertain it. Policies have been modified accordingly to include those new methods and avoid undue executions.