### PR TITLE
Create /etc/gecos/environment file

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,6 +60,21 @@ cron 'GECOS Agent' do
   action :create
 end
 
+env_hash = {
+  gecos_path_ids: node.normal['gecos_path_ids'],
+  gecos_path_names: node.normal['gecos_path_names']
+}
+
+Chef::Log.info('Create /etc/gecos/environment file ')
+template '/etc/gecos/environment' do
+  source 'environment.erb'
+  owner 'root'
+  group 'root'
+  mode '0755'
+  variables env_hash
+  action :nothing
+end.run_action(:create)
+
 include_recipe 'gecos_ws_mgmt::required_packages'
 include_recipe 'gecos_ws_mgmt::software_mgmt'
 include_recipe 'gecos_ws_mgmt::misc_mgmt'

--- a/templates/default/environment.erb
+++ b/templates/default/environment.erb
@@ -1,0 +1,10 @@
+#-------------------------------------
+# GECOS related environment variables
+#-------------------------------------
+
+# GECOS path node IDs (comma separated)
+export GECOS_PATH_IDS="<%= @gecos_path_ids %>"
+
+# GECOS path node names (comma separated)
+export GECOS_PATH_NAMES="<%= @gecos_path_names %>"
+


### PR DESCRIPTION
The  /etc/gecos/environment file contains "gecos_path_ids" and "gecos_path_names" values. This file can be used by bash scripts to load "gecos_path_ids" and "gecos_path_names" as environment variables to perform actions based on the GECOS Control Center path where the computer is located.