### PR TITLE
Replace "p12passwd" by "p12passwdenc" and "password" by "passwordenc".

### DIFF
--- a/providers/forticlientvpn.rb
+++ b/providers/forticlientvpn.rb
@@ -8,7 +8,7 @@
 # All rights reserved - EUPL License V 1.1
 # http://www.osor.eu/eupl
 
-HISTORY_FILTER = /^profile|^p12passwd|^path|^password|^user|^port|^server/
+HISTORY_FILTER = /^profile|^p12passwdenc|^path|^passwordenc|^user|^port|^server/
 
 action :setup do
   begin
@@ -79,9 +79,9 @@ action :setup do
             connections[name] = {}
             connections[name]['server'] = conn[:server]
             connections[name]['port'] = conn[:port]
-            connections[name]['p12passwd'] = ''
+            connections[name]['p12passwdenc'] = ''
             connections[name]['path'] = ''
-            connections[name]['password'] = ''
+            connections[name]['passwordenc'] = ''
             connections[name]['user'] = ''
           else
             # update host/port for connection if values were updated in node

--- a/templates/default/fctlsslvpnhistory.erb
+++ b/templates/default/fctlsslvpnhistory.erb
@@ -10,9 +10,9 @@ autostart=<%= @autostart %>
 if not @connections.nil?
   @connections.each_pair do |conn_name, conn| %>
 profile=<%= conn_name %>
-p12passwd=<%= conn["p12passwd"] %>
+p12passwdenc=<%= conn["p12passwdenc"] %>
 path=<%= conn["path"] %>
-password=<%= conn["password"] %>
+passwordenc=<%= conn["passwordenc"] %>
 user=<%= conn["user"] %>
 port=<%= conn["port"] %>
 server=<%= conn["server"] %>


### PR DESCRIPTION
Recent versions of Fortinet VPN client encodes the passwords.