### PR TITLE
Fix autoreversible policies check

### DIFF
--- a/libraries/Runnable.rb
+++ b/libraries/Runnable.rb
@@ -69,8 +69,8 @@ module Runnable
     end
 
     def policy_autoreversible?(recipe, policy)
-      Runnable::Helper.schema[recipe.to_sym][:properties][
-        policy.to_sym].key?(AUTOREVERSE.to_sym)
+      schem = Runnable::Helper.schema[recipe.to_sym][:properties][policy.to_sym]
+      schem.key?(AUTOREVERSE.to_sym) && schem[AUTOREVERSE.to_sym]
     end
 
     def os_supported?


### PR DESCRIPTION
Current check if only checking if the "autoreverse" key exists in the schema (without checking the value). 
This piece of code also checks the value.