### PR TITLE
Remove exclusiveMinimum and exclusiveMaximum from schema

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -2376,8 +2376,6 @@ folder_sync_js = {
               type: 'integer',
               minimum: 0,
               maximum: 500,
-              exclusiveMinimum: false,
-              exclusiveMaximum: false,
               description: 'Between 0 and 500 KB/s'
             },
             owncloud_download_bandwith: {
@@ -2386,8 +2384,6 @@ folder_sync_js = {
               type: 'integer',
               minimum: 0,
               maximum: 500,
-              exclusiveMinimum: false,
-              exclusiveMaximum: false,
               description: 'Between 0 and 500 KB/s'
             },
             owncloud_folders: {


### PR DESCRIPTION
Default value for exclusiveMinimum and exclusiveMaximum is false in Draft 4 and change the use and meaning in more recent Drafts.

MORE INFO:  https://json-schema.org/understanding-json-schema/reference/numeric.html#range