### PR TITLE
Add Gecos V5 and fix broken policies

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,11 +7,9 @@
 # All rights reserved - EUPL License V 1.1
 # http://www.osor.eu/eupl
 #
-ALL_GECOS_VERS = ['GECOS V4', 'GECOS V3', 'GECOS V2', 'GECOS V3 Lite',
-                  'Gecos V2 Lite'].freeze
-UBUNTU_BASED = ['GECOS V4', 'GECOS V3', 'GECOS V2', 'GECOS V3 Lite',
-                'Gecos V2 Lite', 'Ubuntu 14.04.1 LTS'].freeze
-GECOS_FULL = ['GECOS V4', 'GECOS V3', 'GECOS V2'].freeze
+ALL_GECOS_VERS = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
+UBUNTU_BASED = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
+GECOS_FULL = ['GECOS V4', 'GECOS V3', 'GECOS V5'].freeze
 
 default[:gecos_ws_mgmt][:single_node][:network_res][:job_ids] = []
 default[:gecos_ws_mgmt][:single_node][:network_res][

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -8,6 +8,7 @@
 # http://www.osor.eu/eupl
 #
 ALL_GECOS_VERS = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
+ALL_GECOS_VERS_EXV5 = ['GECOS V4', 'GECOS V3', 'GECOS V3 Lite'].freeze
 UBUNTU_BASED = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
 GECOS_FULL = ['GECOS V4', 'GECOS V3', 'GECOS V5'].freeze
 
@@ -133,7 +134,7 @@ default[:gecos_ws_mgmt][:misc_mgmt][:power_conf_res][:usb_autosuspend] = ''
 default[:gecos_ws_mgmt][:misc_mgmt][:power_conf_res][:job_ids] = []
 default[:gecos_ws_mgmt][:misc_mgmt][:power_conf_res][:updated_by] = {}
 default[:gecos_ws_mgmt][:misc_mgmt][:power_conf_res][
-  :support_os] = ALL_GECOS_VERS
+  :support_os] = ALL_GECOS_VERS_EXV5
 
 default[:gecos_ws_mgmt][:misc_mgmt][:local_users_res][:users_list] = []
 default[:gecos_ws_mgmt][:misc_mgmt][:local_users_res][:job_ids] = []

--- a/metadata.rb
+++ b/metadata.rb
@@ -2993,11 +2993,9 @@ remote_control_js = {
   }
 }
 
-ALL_GECOS_VERS = ['GECOS V4', 'GECOS V3', 'GECOS V2', 'GECOS V3 Lite',
-                  'Gecos V2 Lite'].freeze
-UBUNTU_BASED = ['GECOS V4', 'GECOS V3', 'GECOS V2', 'GECOS V3 Lite',
-                'Gecos V2 Lite', 'Ubuntu 14.04.1 LTS'].freeze
-GECOS_FULL = ['GECOS V4', 'GECOS V3', 'GECOS V2'].freeze
+ALL_GECOS_VERS = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
+UBUNTU_BASED = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
+GECOS_FULL = ['GECOS V4', 'GECOS V3', 'GECOS V5'].freeze
 debug_mode_js[:properties][:support_os][:default] = ALL_GECOS_VERS
 network_resource_js[:properties][:support_os][:default] = ALL_GECOS_VERS
 tz_date_js[:properties][:support_os][:default] = ALL_GECOS_VERS

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,7 +14,7 @@ maintainer        'GECOS Team'
 maintainer_email  'gecos@guadalinex.org'
 license           'Apache 2.0'
 description       'Cookbook for GECOS Workstations management'
-version           '0.11.3'
+version           '0.11.4'
 
 supports 'ubuntu'
 supports 'debian'

--- a/metadata.rb
+++ b/metadata.rb
@@ -2994,6 +2994,7 @@ remote_control_js = {
 }
 
 ALL_GECOS_VERS = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
+ALL_GECOS_VERS_EXV5 = ['GECOS V4', 'GECOS V3', 'GECOS V3 Lite'].freeze
 UBUNTU_BASED = ['GECOS V4', 'GECOS V3', 'GECOS V5', 'GECOS V3 Lite'].freeze
 GECOS_FULL = ['GECOS V4', 'GECOS V3', 'GECOS V5'].freeze
 debug_mode_js[:properties][:support_os][:default] = ALL_GECOS_VERS
@@ -3005,7 +3006,7 @@ local_file_js[:properties][:support_os][:default] = ALL_GECOS_VERS
 auto_updates_js[:properties][:support_os][:default] = ALL_GECOS_VERS
 boot_lock_js[:properties][:support_os][:default] = UBUNTU_BASED
 local_groups_js[:properties][:support_os][:default] = ALL_GECOS_VERS
-power_conf_js[:properties][:support_os][:default] = ALL_GECOS_VERS
+power_conf_js[:properties][:support_os][:default] = ALL_GECOS_VERS_EXV5
 local_admin_users_js[:properties][:support_os][:default] = ALL_GECOS_VERS
 software_sources_js[:properties][:support_os][:default] = ALL_GECOS_VERS
 package_js[:properties][:support_os][:default] = UBUNTU_BASED

--- a/recipes/required_packages.rb
+++ b/recipes/required_packages.rb
@@ -47,5 +47,6 @@ when 'GECOS V4'
 when 'GECOS V5'
   $required_pkgs['desktop_background'] = ['dconf-editor']
   $required_pkgs['shutdown_options'] = ['dconf-editor']
+  $required_pkgs['printers'].delete('foomatic-db-gutenprint')
 
 end

--- a/recipes/required_packages.rb
+++ b/recipes/required_packages.rb
@@ -44,4 +44,8 @@ when 'GECOS V4'
   $required_pkgs['local_users'] = ['ruby-shadow']
   $required_pkgs['printers'].delete('foomatic-db-gutenprint')
 
+when 'GECOS V5'
+  $required_pkgs['desktop_background'] = ['dconf-editor']
+  $required_pkgs['shutdown_options'] = ['dconf-editor']
+
 end

--- a/recipes/required_packages.rb
+++ b/recipes/required_packages.rb
@@ -48,5 +48,5 @@ when 'GECOS V5'
   $required_pkgs['desktop_background'] = ['dconf-editor']
   $required_pkgs['shutdown_options'] = ['dconf-editor']
   $required_pkgs['printers'].delete('foomatic-db-gutenprint')
-
+  $required_pkgs['local_users'] = ['ruby-shadow']
 end


### PR DESCRIPTION
The cookbook has been updated to include V5 and the following policies has been fixed (package related issues):  

- Fondo de escritorio
- Opciones de apagado
- Impresoras
- Usuarios
- Administración de energía
